### PR TITLE
Add macOS envtest support and Apache LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,195 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and incorporated
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any Contributor
+      Contribution constitutes direct or contributory patent infringement,
+      then any and all licenses granted to You under this License for that
+      Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the
+          License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, and to permit persons to whom the Contribution is
+      furnished to do so, subject to the following terms and conditions.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only on
+      Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format, and the file or
+      class name and description of purpose be included on the same
+      "printed page" as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/e2e/binaries.go
+++ b/tests/e2e/binaries.go
@@ -20,13 +20,16 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
-// defaultKubeVersion is the kube-apiserver release downloaded by default.
-// Override with the KUBE_APISERVER_VERSION environment variable.
+// defaultKubeVersion is the kube-apiserver release used by default. Override
+// with the KUBE_APISERVER_VERSION environment variable. On Linux this is the
+// exact dl.k8s.io release; on macOS its minor version selects the envtest build.
 const defaultKubeVersion = "v1.36.2"
 
 func kubeVersion() string {
@@ -36,13 +39,16 @@ func kubeVersion() string {
 	return defaultKubeVersion
 }
 
-// skipIfUnsupported skips the test on platforms where kube-apiserver is not
-// published. dl.k8s.io ships kube-apiserver only for linux/{amd64,arm64};
-// macOS users normally obtain it via envtest/kubebuilder instead.
+// skipIfUnsupported skips the test on platforms where we cannot obtain a
+// kube-apiserver binary. It is available for linux/{amd64,arm64} from dl.k8s.io
+// and for darwin/{amd64,arm64} from the envtest (kubebuilder-tools) distribution.
 func skipIfUnsupported(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS != "linux" {
-		t.Skipf("kube-apiserver is published only for linux on dl.k8s.io (current platform: %s/%s); run this e2e in CI or a Linux environment", runtime.GOOS, runtime.GOARCH)
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		return
+	default:
+		t.Skipf("kube-apiserver e2e supports only linux (dl.k8s.io) and darwin (envtest); current platform: %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 }
 
@@ -65,9 +71,21 @@ func repoRoot(t *testing.T) string {
 	}
 }
 
-// ensureKubeAPIServer downloads (and caches under .build/) the kube-apiserver
-// binary for the current platform, returning the path to the executable.
+// ensureKubeAPIServer returns the path to a kube-apiserver binary for the
+// current platform, downloading and caching it under .build/ if necessary.
+// On Linux it fetches the official release from dl.k8s.io; on macOS, where
+// dl.k8s.io has no server builds, it uses setup-envtest (kubebuilder-tools).
 func ensureKubeAPIServer(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		return ensureKubeAPIServerFromEnvtest(ctx, t)
+	}
+	return ensureKubeAPIServerFromRelease(ctx, t)
+}
+
+// ensureKubeAPIServerFromRelease downloads the official kube-apiserver release
+// binary from dl.k8s.io (Linux).
+func ensureKubeAPIServerFromRelease(ctx context.Context, t *testing.T) string {
 	t.Helper()
 	version := kubeVersion()
 	cacheDir := filepath.Join(repoRoot(t), ".build", "e2e-bin", version)
@@ -96,6 +114,63 @@ func ensureKubeAPIServer(ctx context.Context, t *testing.T) string {
 		t.Fatalf("rename kube-apiserver into place: %v", err)
 	}
 	return binPath
+}
+
+// ensureKubeAPIServerFromEnvtest uses setup-envtest to download the
+// kubebuilder-tools bundle (which includes a darwin kube-apiserver) and returns
+// the path to its kube-apiserver. envtest publishes one build per minor version,
+// so we request the minor of kubeVersion() (e.g. "1.36.x") and let it pick the
+// latest available patch, which may differ from the dl.k8s.io patch.
+func ensureKubeAPIServerFromEnvtest(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	binDir := filepath.Join(repoRoot(t), ".build", "envtest")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", binDir, err)
+	}
+
+	selector := envtestVersionSelector(kubeVersion())
+	module := "sigs.k8s.io/controller-runtime/tools/setup-envtest@" + setupEnvtestRef()
+	t.Logf("fetching kube-apiserver via setup-envtest (version %s, %s/%s) into %s", selector, runtime.GOOS, runtime.GOARCH, binDir)
+
+	// `setup-envtest use ... -p path` downloads/caches the bundle (a no-op when
+	// already present) and prints the directory containing the binaries.
+	cmd := exec.CommandContext(ctx, "go", "run", module,
+		"use", selector,
+		"--bin-dir", binDir,
+		"--os", runtime.GOOS,
+		"--arch", runtime.GOARCH,
+		"-p", "path",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("setup-envtest failed: %v\n%s", err, stderr.String())
+	}
+
+	dir := strings.TrimSpace(string(out))
+	binPath := filepath.Join(dir, "kube-apiserver")
+	if _, err := os.Stat(binPath); err != nil {
+		t.Fatalf("kube-apiserver not found at %s after setup-envtest: %v", binPath, err)
+	}
+	return binPath
+}
+
+func setupEnvtestRef() string {
+	if v := os.Getenv("SETUP_ENVTEST_VERSION"); v != "" {
+		return v
+	}
+	return "latest"
+}
+
+// envtestVersionSelector converts a kube version like "v1.36.2" into the envtest
+// selector "1.36.x".
+func envtestVersionSelector(v string) string {
+	v = strings.TrimPrefix(v, "v")
+	if parts := strings.Split(v, "."); len(parts) >= 2 {
+		return parts[0] + "." + parts[1] + ".x"
+	}
+	return v
 }
 
 func download(ctx context.Context, url, dest string) error {


### PR DESCRIPTION
## Summary

Final consolidation onto `main`:

- **macOS e2e support** (`tests/e2e/binaries.go`): on darwin, fetch `kube-apiserver` via `setup-envtest` (kubebuilder-tools), so the e2e suite runs locally on a Mac; Linux still uses dl.k8s.io. This is the content of PR #7, which had merged into a side branch rather than `main`.
- **`LICENSE.md`**: Apache 2.0, which previously lived only on the old `batch_commit` branch (`main` had no license).

After this merges, `main` will be made the default branch and the leftover branches deleted, leaving `main` as the single line of development.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- The envtest path was validated end-to-end locally on darwin/arm64 (in PR #7): `RUN_E2E=1 go test ./tests/e2e/...` boots kube-apiserver v1.36.0 against cloudetcd and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
