### PR TITLE
Use signal.NotifyContext for graceful shutdown

### DIFF
--- a/cmd/cloud-etcd/main.go
+++ b/cmd/cloud-etcd/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -36,8 +35,9 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// Cancel the context on SIGINT/SIGTERM for graceful shutdown.
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	// Parse command line flag
 	addr := ":2379"
@@ -60,16 +60,6 @@ func run(ctx context.Context) error {
 
 	// Create and start the etcd API server
 	server := api.NewServer(store)
-
-	// Handle graceful shutdown
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		<-sigChan
-		fmt.Println("\nShutting down server...")
-		cancel()
-	}()
 
 	// Start the server
 	if err := server.Start(ctx, addr); err != nil {


### PR DESCRIPTION
## Summary
Replaces the manual `os.Signal` channel + goroutine in `cmd/cloud-etcd/main.go` with `signal.NotifyContext`, which cancels the run context on SIGINT/SIGTERM. This is the idiomatic stdlib pattern and removes the explicit `context.WithCancel`, the signal channel, and the watcher goroutine.

Fixes #12

## Test plan
- [x] ap-verify-generate / ap-lint / ap-test / ap-e2e all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)