### PR TITLE
docs: focus on Google Cloud Storage (GCS), not DynamoDB

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,8 @@
 ## Project Summary: cloud-etcd
 
-`cloud-etcd` is a custom implementation of the etcd API designed to be backed by cloud storage services, with Google Cloud Storage (GCS) as the initial target.
+`cloud-etcd` is a custom implementation of the etcd API designed to be backed by cloud storage services, with Google Cloud Storage (GCS) as the target.
+
+The goal is to be simple and low cost rather than high performance: by using a managed object store like GCS as the source of truth, `cloud-etcd` avoids operating a stateful etcd cluster.
 
 The core architectural principle is to use the cloud storage as a write-ahead log, complemented by a local on-disk cache for fast read operations. This design avoids the need for a consensus protocol like Raft, relying instead on the consistency guarantees of the cloud provider's storage service.
 
@@ -15,7 +17,7 @@ The project is in its early stages but has already implemented several key featu
 ### Next Steps
 
 The immediate goals for the project are:
-1.  Implement the storage interface for AWS DynamoDB.
+1.  Implement the storage interface for Google Cloud Storage (GCS).
 2.  Develop a persistent local cache using a tool like BoltDB or LevelDB.
 3.  Build the replicator component to synchronize the local cache with the cloud storage.
 4.  Implement the `Watch` API for monitoring changes.

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -119,13 +119,13 @@ kube-apiserver \
                                   │
                     ┌─────────────▼─────────────┐
                     │    Storage Interface      │
-                    │    (Memory/DynamoDB)     │
+                    │    (Memory/GCS)          │
                     └───────────────────────────┘
 ```
 
 ## Next Steps
 
-1. **DynamoDB Implementation**: Replace memory storage with DynamoDB
+1. **GCS Implementation**: Replace memory storage with Google Cloud Storage (GCS)
 2. **Local Cache**: Implement persistent local cache (BoltDB/LevelDB)
 3. **Replicator**: Implement background replication from cloud storage
 4. **Watch API**: Implement etcd's watch functionality

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # cloud-etcd
 
-A custom implementation of the etcd API designed to be backed by cloud storage services, initially targeting AWS DynamoDB.
+A custom implementation of the etcd API designed to be backed by cloud storage services, with Google Cloud Storage (GCS) as the target.
 
 ## Overview
 
-cloud-etcd provides an etcd-compatible API endpoint that can be used as a backend for Kubernetes (specifically `kube-apiserver`), while leveraging cloud-native storage for persistence and scalability.
+cloud-etcd provides an etcd-compatible API endpoint that can be used as a backend for Kubernetes (specifically `kube-apiserver`), while leveraging cloud-native storage for persistence and durability.
+
+The goal is not raw performance — it is to be **simple and low cost**. By treating an object store like GCS as the source of truth, cloud-etcd avoids running and operating a stateful etcd cluster, and instead relies on the durability, availability, and low cost of managed object storage.
 
 The core design principle is to treat the cloud storage as a write-ahead log (or change log). A local, on-disk cache stores the materialized view of the data for fast read access. This approach avoids the need for a traditional distributed consensus protocol like Raft, as it relies on the consistency guarantees of the underlying cloud storage service.
 
@@ -90,7 +92,7 @@ cloudetcd/
 
 ## Next Steps
 
-1. **DynamoDB Implementation**: Implement the storage interface using DynamoDB
+1. **GCS Implementation**: Implement the storage interface using Google Cloud Storage (GCS)
 2. **Local Cache**: Implement persistent local cache (BoltDB/LevelDB)
 3. **Replicator**: Implement the component that keeps local cache in sync
 4. **Watch API**: Implement etcd's watch functionality

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,12 @@
 # Architecture: cloud-etcd
 
-This document outlines the architecture for `cloud-etcd`, a custom implementation of the etcd API, designed to be backed by cloud storage services. The initial implementation will target AWS DynamoDB.
+This document outlines the architecture for `cloud-etcd`, a custom implementation of the etcd API, designed to be backed by cloud storage services. The implementation targets Google Cloud Storage (GCS).
 
 ## 1. Overview
 
-The primary goal of `cloud-etcd` is to provide an etcd-compatible API endpoint that can be used as a backend for Kubernetes (specifically `kube-apiserver`), while leveraging cloud-native storage for persistence and scalability.
+The primary goal of `cloud-etcd` is to provide an etcd-compatible API endpoint that can be used as a backend for Kubernetes (specifically `kube-apiserver`), while leveraging cloud-native storage for persistence and durability.
+
+The design optimizes for **simplicity and low cost** rather than high performance. Using a managed object store such as GCS as the source of truth means there is no stateful etcd cluster to run, operate, or scale — durability and availability are inherited from the object store, which is inexpensive and requires no operational overhead.
 
 The core design principle is to treat the cloud storage as a write-ahead log (or change log). A local, on-disk cache will store the materialized view of the data for fast read access. This approach avoids the need for a traditional distributed consensus protocol like Raft, as it relies on the consistency guarantees of the underlying cloud storage service.
 
@@ -19,34 +21,33 @@ This layer is responsible for handling incoming gRPC requests from clients like 
 - **API Implemented**: Key-Value, Watch, Lease.
 - **Functionality**: It will parse incoming requests, delegate write operations to the change log, and serve read requests from the local cache. For watch operations, it will tail the change log.
 
-### 2.2. Change Log (DynamoDB)
+### 2.2. Change Log (GCS)
 
-The change log is the source of truth for all data modifications. It is stored in a DynamoDB table.
+The change log is the source of truth for all data modifications. It is stored as a sequence of objects in a Google Cloud Storage (GCS) bucket.
 
-- **Table Schema**:
-    - **Partition Key**: `keyspace` (e.g., a constant like `"default"`)
-    - **Sort Key**: `revision` (a monotonically increasing integer)
-    - **Attributes**:
+- **Object Layout**:
+    - Each entry (or batch of entries) is written as an object whose name encodes the `revision`, a monotonically increasing integer (e.g., zero-padded so that lexical listing order matches revision order).
+    - **Object Contents** (per change):
         - `operation_type`: (e.g., `PUT`, `DELETE`)
         - `key`: The key of the data being modified.
         - `value`: The value being written (for `PUT` operations).
         - `lease_id`: The ID of the associated lease.
         - `timestamp`: The time of the operation.
 
-This structure allows for efficient querying of changes in chronological order.
+Ordering the change log by revision in the object name allows changes to be listed and replayed in chronological order. GCS's strong consistency and atomic, conditional (generation-based) writes are used to append entries safely and to avoid two writers claiming the same revision.
 
 ### 2.3. Local Cache
 
 To provide low-latency read access, `cloud-etcd` will maintain a local cache of the key-value store. This cache can be stored on a local disk (e.g., using a key-value store library like BoltDB or LevelDB) or even in memory on a `tmpfs` volume for maximum performance.
 
 - **Structure**: A simple key-value map.
-- **Consistency**: The cache is updated *after* a write has been successfully committed to the DynamoDB change log.
+- **Consistency**: The cache is updated *after* a write has been successfully committed to the GCS change log.
 
 ### 2.4. Replicator
 
 The Replicator is responsible for keeping the Local Cache in sync with the Change Log.
 
-- **On Startup**: During startup, the replicator reads the change log from DynamoDB from the last known revision and applies the changes to the local cache to bring it up to date. If the cache is empty, it replays the entire log.
+- **On Startup**: During startup, the replicator reads the change log from GCS from the last known revision and applies the changes to the local cache to bring it up to date. If the cache is empty, it replays the entire log.
 - **In Background**: It can run in the background to apply changes continuously, though for the first implementation, we will focus on startup replication.
 
 ## 3. Workflows
@@ -56,7 +57,7 @@ The Replicator is responsible for keeping the Local Cache in sync with the Chang
 1.  Initialize the etcd API layer.
 2.  Check for the existence of a local cache.
 3.  If the cache exists, read the last applied revision number.
-4.  The Replicator queries DynamoDB for all changes since the last applied revision.
+4.  The Replicator lists the GCS change log for all changes since the last applied revision.
 5.  The Replicator applies these changes in order to the local cache.
 6.  The server begins accepting traffic.
 
@@ -64,19 +65,19 @@ The Replicator is responsible for keeping the Local Cache in sync with the Chang
 
 1.  A write request is received by the etcd API Layer.
 2.  A new revision number is generated.
-3.  The change (operation type, key, value) is written to the DynamoDB change log with the new revision number.
-4.  Once the write to DynamoDB is confirmed, the change is applied to the local cache.
+3.  The change (operation type, key, value) is written to the GCS change log with the new revision number.
+4.  Once the write to GCS is confirmed, the change is applied to the local cache.
 5.  A success response is sent to the client.
 
 ### 3.3. Read Operations (e.g., GET)
 
 1.  A read request is received by the etcd API Layer.
 2.  The key is looked up directly in the local cache.
-3.  The value from the cache is returned to the client. This ensures reads are fast and do not require a round-trip to DynamoDB.
+3.  The value from the cache is returned to the client. This ensures reads are fast and do not require a round-trip to GCS.
 
 ## 4. Future Considerations
 
-- **Snapshots**: To speed up startup time for very large change logs, a snapshotting mechanism can be introduced. A background process would periodically compact the log up to a certain revision and store a full snapshot of the data in S3. The Replicator would then restore from the latest snapshot and replay only the changes that occurred after the snapshot was taken.
-- **Watch API**: The Watch API will be implemented by tailing the DynamoDB change log. When a client creates a watch, the server will query the change log for any changes after the requested revision and stream them back.
+- **Snapshots**: To speed up startup time for very large change logs, a snapshotting mechanism can be introduced. A background process would periodically compact the log up to a certain revision and store a full snapshot of the data as an object in GCS. The Replicator would then restore from the latest snapshot and replay only the changes that occurred after the snapshot was taken.
+- **Watch API**: The Watch API will be implemented by tailing the GCS change log. When a client creates a watch, the server will query the change log for any changes after the requested revision and stream them back.
 - **Leases**: Leases will be managed by a separate process that periodically checks for expired leases and writes corresponding `DELETE` operations to the change log.
-- **Multi-node**: While the initial design is single-node, a multi-node setup for high availability could be achieved by having multiple `cloud-etcd` instances running, each with its own local cache, all reading from the same DynamoDB change log. A mechanism for leader election would be needed for write operations to avoid conflicting revision numbers. 
+- **Multi-node**: While the initial design is single-node, a multi-node setup for high availability could be achieved by having multiple `cloud-etcd` instances running, each with its own local cache, all reading from the same GCS change log. A mechanism for leader election would be needed for write operations to avoid conflicting revision numbers. 

--- a/pkg/persistence/README.md
+++ b/pkg/persistence/README.md
@@ -97,9 +97,9 @@ Every `Put` and `Delete` operation is automatically appended to the log before b
 
 Planned implementations include:
 
-- **DynamoDBLog**: A DynamoDB-backed implementation for production use
+- **GCSLog**: A Google Cloud Storage (GCS)-backed implementation for production use
 - **FileLog**: A file-based implementation for local development
-- **DynamoDBSnapshotter**: A DynamoDB-backed snapshot implementation
+- **GCSSnapshotter**: A Google Cloud Storage (GCS)-backed snapshot implementation
 
 ## Usage Example
 


### PR DESCRIPTION
## Summary

Reframes the project documentation so that **Google Cloud Storage (GCS)** is the storage target throughout, replacing the earlier AWS DynamoDB (and S3) framing. Per the issue, the intent is no longer high-performance DynamoDB-style storage but a **simple, low-cost** design built on an object store.

Changes:
- **README.md** — target is GCS; added a note that the goal is simplicity and low cost, not raw performance; "DynamoDB Implementation" next step → "GCS Implementation".
- **GEMINI.md** — GCS as the target (not "initial target"); added simple/low-cost framing; next step now targets GCS.
- **docs/architecture.md** — overview reframed around GCS and the simplicity/low-cost goal; "Change Log (DynamoDB)" section rewritten from a DynamoDB table schema to a GCS object layout (revision-encoded object names, generation-based conditional writes); all workflow/future-consideration references (DynamoDB, S3) updated to GCS.
- **IMPLEMENTATION_SUMMARY.md** — storage diagram and next step updated to GCS.
- **pkg/persistence/README.md** — planned `DynamoDBLog`/`DynamoDBSnapshotter` → `GCSLog`/`GCSSnapshotter`.

No code changes — documentation only.

Fixes #13

## Test plan
- [x] ap-verify-generate passes
- [x] ap-lint passes
- [x] ap-test passes
- [x] ap-e2e passes (TestKubeAPIServerSmoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)