### PR TITLE
Per-key read-version conflict detection for batch commits

### DIFF
--- a/pkg/persistence/batch/batch.go
+++ b/pkg/persistence/batch/batch.go
@@ -39,6 +39,12 @@ type TxnBatch struct {
 
 	flushFunc func(ctx context.Context, lastLogPosition Revision, batch *BatchCommit) error
 
+	// committedWrites is shared across all batches (owned by Batching) and
+	// records, for each key, the highest revision at which it has been
+	// written. It is only accessed under the Batching flushLock, which
+	// serializes all flushes. It is used for per-key conflict validation.
+	committedWrites map[string]Revision
+
 	pendingBatch []*PendingTxn
 	// pendingBatch []*PendingTransaction
 	// batchTimer   *time.Timer
@@ -147,8 +153,8 @@ func (b *TxnBatch) flush(ctx context.Context, lastLogPosition Revision) (int, er
 	resultChannels := make([]chan BatchResult, 0, len(b.pendingBatch))
 	revision := lastLogPosition
 	for _, txn := range b.pendingBatch {
-		if txn.Meta.SnapshotRevision != lastLogPosition {
-			log.Info("Skipping transaction with unexpected snapshot revision", "snapshotTimestamp", txn.Meta.SnapshotRevision, "lastLogPosition", lastLogPosition)
+		if !validateTxn(txn.Meta, lastLogPosition, b.committedWrites) {
+			log.Info("Skipping transaction due to conflict", "snapshotRevision", txn.Meta.SnapshotRevision, "lastLogPosition", lastLogPosition, "hasRangeRead", txn.Meta.HasRangeRead)
 			txn.resultChan <- BatchResult{
 				Revision: 0,
 				Success:  false,
@@ -189,8 +195,14 @@ func (b *TxnBatch) flush(ctx context.Context, lastLogPosition Revision) (int, er
 	}
 
 	revision = lastLogPosition
-	for _, resultChannel := range resultChannels {
+	for i, resultChannel := range resultChannels {
 		revision++
+		// Record this transaction's writes at their committed revision so
+		// that subsequent transactions (in later batches) validate their
+		// reads and writes against them.
+		for key := range commit.Transactions[i].Meta.WriteSet {
+			b.committedWrites[key] = revision
+		}
 		resultChannel <- BatchResult{
 			Revision: revision,
 			Success:  true,
@@ -199,4 +211,43 @@ func (b *TxnBatch) flush(ctx context.Context, lastLogPosition Revision) (int, er
 	}
 
 	return len(commit.Transactions), nil
+}
+
+// validateTxn reports whether a transaction can still be committed given the
+// keys that have been written since its snapshot (committedWrites).
+//
+// This is textbook optimistic-concurrency backward-validation, done per key:
+//   - a point key we read must not have been written by a concurrently
+//     committed transaction since we read it; and
+//   - a key we write must not have been written by a concurrently committed
+//     transaction since our snapshot (write-write conflict).
+//
+// Disjoint transactions therefore never abort each other, unlike the previous
+// coarse "did the global revision move" check.
+//
+// A transaction that performed a range read cannot be validated per-key (it is
+// exposed to phantoms), so it falls back to the conservative whole-snapshot
+// check: it commits only if nothing at all has committed since its snapshot.
+func validateTxn(meta *TxnMeta, lastLogPosition Revision, committedWrites map[string]Revision) bool {
+	if meta.HasRangeRead {
+		return meta.SnapshotRevision == lastLogPosition
+	}
+
+	// Read validation: every point key we read must not have changed since
+	// the version we observed for it.
+	for key, readRevision := range meta.ReadSet {
+		if committedWrites[key] > readRevision {
+			return false
+		}
+	}
+
+	// Write validation: a key we write must not have been written by another
+	// transaction that committed after our snapshot.
+	for key := range meta.WriteSet {
+		if committedWrites[key] > meta.SnapshotRevision {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/persistence/batch/batch_test.go
+++ b/pkg/persistence/batch/batch_test.go
@@ -31,13 +31,13 @@ func TestTxnEffects_CanBatchWith(t *testing.T) {
 			name: "no conflicts - can batch",
 			txn1: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key1")
+				txn.AddRead("key1", 0)
 				txn.AddWrite("key2")
 				return txn
 			}(),
 			txn2: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key3")
+				txn.AddRead("key3", 0)
 				txn.AddWrite("key4")
 				return txn
 			}(),
@@ -61,7 +61,7 @@ func TestTxnEffects_CanBatchWith(t *testing.T) {
 			name: "read-write - can batch",
 			txn1: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key1")
+				txn.AddRead("key1", 0)
 				return txn
 			}(),
 			txn2: func() *TxnMeta {
@@ -80,7 +80,7 @@ func TestTxnEffects_CanBatchWith(t *testing.T) {
 			}(),
 			txn2: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key1")
+				txn.AddRead("key1", 0)
 				return txn
 			}(),
 			expected: false,
@@ -89,15 +89,15 @@ func TestTxnEffects_CanBatchWith(t *testing.T) {
 			name: "multiple keys - mixed conflicts",
 			txn1: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key1")
+				txn.AddRead("key1", 0)
 				txn.AddWrite("key2")
 				txn.AddWrite("key3")
 				return txn
 			}(),
 			txn2: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key3") // Conflicts with txn1's write of key3
-				txn.AddRead("key4")
+				txn.AddRead("key3", 0) // Conflicts with txn1's write of key3
+				txn.AddRead("key4", 0)
 				return txn
 			}(),
 			expected: false,
@@ -106,13 +106,13 @@ func TestTxnEffects_CanBatchWith(t *testing.T) {
 			name: "multiple keys - no conflicts",
 			txn1: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key1")
+				txn.AddRead("key1", 0)
 				txn.AddWrite("key2")
 				return txn
 			}(),
 			txn2: func() *TxnMeta {
 				txn := persistence.NewTxnMeta(1)
-				txn.AddRead("key3")
+				txn.AddRead("key3", 0)
 				txn.AddWrite("key4")
 				return txn
 			}(),

--- a/pkg/persistence/batch/batching.go
+++ b/pkg/persistence/batch/batching.go
@@ -35,12 +35,18 @@ type Batching struct {
 
 	flushLock       sync.Mutex
 	lastLogPosition Revision
+	// committedWrites records, for each key, the highest revision at which it
+	// has been written since batching started. It is only accessed under
+	// flushLock (held for the duration of flushBatch), so per-key conflict
+	// validation and its updates are serialized with the log commit.
+	committedWrites map[string]Revision
 }
 
 func NewBatching(lastLogPosition Revision, flushFunc FlushFunc) *Batching {
 	b := &Batching{
 		flushFunc:       flushFunc,
 		lastLogPosition: lastLogPosition,
+		committedWrites: make(map[string]Revision),
 	}
 	b.batchLockCond = sync.NewCond(&b.batchLock)
 
@@ -48,9 +54,10 @@ func NewBatching(lastLogPosition Revision, flushFunc FlushFunc) *Batching {
 	return b
 }
 
-func newTxnBatch(flushFunc FlushFunc) *TxnBatch {
+func newTxnBatch(flushFunc FlushFunc, committedWrites map[string]Revision) *TxnBatch {
 	return &TxnBatch{
-		flushFunc: flushFunc,
+		flushFunc:       flushFunc,
+		committedWrites: committedWrites,
 	}
 }
 
@@ -71,7 +78,7 @@ func (b *Batching) Add(ctx context.Context, logRecord *LogRecord, txnMeta *TxnMe
 	}
 
 	if resultChan == nil {
-		batch := newTxnBatch(b.flushFunc)
+		batch := newTxnBatch(b.flushFunc, b.committedWrites)
 		b.openBatch = batch
 		shouldNotify = true
 

--- a/pkg/persistence/logtests/basic.go
+++ b/pkg/persistence/logtests/basic.go
@@ -70,6 +70,10 @@ func RunAll(t *testing.T, logFactory func(t *testing.T) persistence.Log) {
 		log := logFactory(t)
 		TestLog_BatchCommit_ReadWriteConflicts(t, log)
 	})
+	t.Run("BatchCommit_DisjointKeysNoFalseAbort", func(t *testing.T) {
+		log := logFactory(t)
+		TestLog_BatchCommit_DisjointKeysNoFalseAbort(t, log)
+	})
 	t.Run("ReadFromRevision", func(t *testing.T) {
 		log := logFactory(t)
 		TestLog_ReadFromRevision(t, log)
@@ -476,7 +480,9 @@ func TestLog_BasicOperations(t *testing.T, log persistence.Log) {
 		},
 	}
 
-	newRevision, success, err := log.Append(ctx, record, NewTxnMeta(1))
+	meta1 := NewTxnMeta(1)
+	meta1.AddWrite("test-key")
+	newRevision, success, err := log.Append(ctx, record, meta1)
 	if err != nil {
 		t.Fatalf("Failed to append record: %v", err)
 	}
@@ -517,8 +523,11 @@ func TestLog_BasicOperations(t *testing.T, log persistence.Log) {
 		t.Errorf("Expected value %s, got %s", string(record.Events[0].Kv.Value), string(retrievedRecord.Events[0].Kv.Value))
 	}
 
-	// Test conditional append with wrong condition
-	_, success, err = log.Append(ctx, record, NewTxnMeta(1)) // Wrong condition position
+	// Test conditional append with wrong condition: a stale snapshot that
+	// rewrites test-key conflicts with the rev-2 write of the same key.
+	staleMeta := NewTxnMeta(1) // Wrong condition position
+	staleMeta.AddWrite("test-key")
+	_, success, err = log.Append(ctx, record, staleMeta)
 	if err != nil {
 		t.Fatalf("Failed to append record: %v", err)
 	}
@@ -527,7 +536,9 @@ func TestLog_BasicOperations(t *testing.T, log persistence.Log) {
 	}
 
 	// Test conditional append with correct condition
-	newRevision2, success, err := log.Append(ctx, record, NewTxnMeta(2))
+	meta2 := NewTxnMeta(2)
+	meta2.AddWrite("test-key")
+	newRevision2, success, err := log.Append(ctx, record, meta2)
 	if err != nil {
 		t.Fatalf("Failed to append record: %v", err)
 	}
@@ -840,7 +851,7 @@ func TestLog_BatchCommit_ReadWriteConflicts(t *testing.T, log persistence.Log) {
 		}
 
 		txn1Meta := NewTxnMeta(baseRev)
-		txn1Meta.AddRead("existing:key")
+		txn1Meta.AddRead("existing:key", baseRev)
 		txn1Meta.AddWrite("audit:1")
 		txn1Record := &LogRecord{
 			Events: []*mvccpb.Event{
@@ -855,8 +866,8 @@ func TestLog_BatchCommit_ReadWriteConflicts(t *testing.T, log persistence.Log) {
 		}
 
 		txn2Meta := NewTxnMeta(baseRev)
-		txn2Meta.AddRead("audit:1")       // Conflicts with txn1's write
-		txn2Meta.AddWrite("existing:key") // Conflicts with txn1's read
+		txn2Meta.AddRead("audit:1", baseRev) // Conflicts with txn1's write
+		txn2Meta.AddWrite("existing:key")    // Conflicts with txn1's read
 		txn2Record := &LogRecord{
 			Events: []*mvccpb.Event{
 				{
@@ -909,7 +920,7 @@ func TestLog_BatchCommit_ReadWriteConflicts(t *testing.T, log persistence.Log) {
 		}
 
 		txn1Meta := NewTxnMeta(baseRev)
-		txn1Meta.AddRead("existing:key")
+		txn1Meta.AddRead("existing:key", baseRev)
 		txn1Meta.AddWrite("audit:2")
 		txn1Record := &LogRecord{
 			Events: []*mvccpb.Event{
@@ -975,4 +986,67 @@ func TestLog_BatchCommit_ReadWriteConflicts(t *testing.T, log persistence.Log) {
 			t.Errorf("Expected 1 or 2 successes for an acyclic antidependency, got %d", successCount)
 		}
 	})
+}
+
+// TestLog_BatchCommit_DisjointKeysNoFalseAbort is a regression test for
+// per-key conflict detection. Writers that touch entirely disjoint keys must
+// all commit, even when they are validated in *different* batches so their
+// snapshot no longer matches the (advanced) log position.
+//
+// This is the exact false-abort the previous coarse "SnapshotRevision !=
+// lastLogPosition" check suffered under concurrency: txn A writes /a and txn B
+// writes /b, both snapshot the same revision; if A commits first, B used to be
+// rejected purely because the global revision moved, despite touching nothing
+// A wrote -- forcing a needless apiserver write retry.
+func TestLog_BatchCommit_DisjointKeysNoFalseAbort(t *testing.T, log persistence.Log) {
+	ctx := t.Context()
+
+	// Initialize with a dummy record so the log starts at revision 1.
+	if _, ok, err := log.Append(ctx, &LogRecord{}, NewTxnMeta(0)); err != nil || !ok {
+		t.Fatalf("Failed to initialize log: %v", err)
+	}
+
+	baseRev, err := log.GetCurrentRevision(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentRevision failed: %v", err)
+	}
+
+	// Submit writers sequentially. Every writer snapshots the same baseRev,
+	// so once the first commits, all subsequent writers have a "stale"
+	// snapshot -- yet because their keys are disjoint they must all commit.
+	const numWriters = 8
+	for i := 0; i < numWriters; i++ {
+		key := fmt.Sprintf("/disjoint/%d", i)
+
+		meta := NewTxnMeta(baseRev)
+		// Guard the write with a compare on its own key (as Kubernetes'
+		// GuaranteedUpdate does): the key does not exist yet, so the
+		// observed read-version is 0.
+		meta.AddRead(key, 0)
+		meta.AddWrite(key)
+
+		record := &LogRecord{
+			Events: []*mvccpb.Event{
+				{
+					Type: mvccpb.PUT,
+					Kv: &mvccpb.KeyValue{
+						Key:   []byte(key),
+						Value: []byte(fmt.Sprintf("value-%d", i)),
+					},
+				},
+			},
+		}
+
+		rev, ok, err := log.Append(ctx, record, meta)
+		if err != nil {
+			t.Fatalf("writer %d returned an unexpected error: %v", i, err)
+		}
+		if !ok {
+			t.Errorf("writer %d for disjoint key %q was falsely aborted despite touching no shared key", i, key)
+			continue
+		}
+		if want := baseRev + Revision(i) + 1; rev != want {
+			t.Errorf("writer %d committed at revision %d, want %d", i, rev, want)
+		}
+	}
 }

--- a/pkg/persistence/txn_meta.go
+++ b/pkg/persistence/txn_meta.go
@@ -16,31 +16,43 @@ package persistence
 
 import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	"k8s.io/klog/v2"
 )
 
 // TxnMeta represents the read and write sets of a transaction
 // to enable serializability checking for batch commits
 type TxnMeta struct {
 	SnapshotRevision Revision
-	// ReadSet contains keys that were read during the transaction
-	ReadSet map[string]bool
+	// ReadSet maps each point key read during the transaction to the
+	// mod_revision observed for that key at snapshot time. A key that did
+	// not exist at snapshot time maps to revision 0. This is used for
+	// per-key (backward-validation) conflict detection at commit time: a
+	// read key is still valid iff it has not been written by a
+	// concurrently-committed transaction since it was read.
+	ReadSet map[string]Revision
 	// WriteSet contains keys that will be written during the transaction
 	WriteSet map[string]bool
+	// HasRangeRead is true if the transaction performed a range/list read.
+	// Range reads cannot be validated per-key (they are vulnerable to
+	// phantoms), so a transaction that recorded one falls back to the
+	// conservative whole-snapshot conflict check. Kubernetes never combines
+	// a range read with a write in the same etcd transaction, so this
+	// fallback is not expected to fire for the Kubernetes workload.
+	HasRangeRead bool
 }
 
 // NewTxnMeta creates a new TxnEffects instance
 func NewTxnMeta(snapshotRevision Revision) *TxnMeta {
 	return &TxnMeta{
-		ReadSet:          make(map[string]bool),
+		ReadSet:          make(map[string]Revision),
 		WriteSet:         make(map[string]bool),
 		SnapshotRevision: snapshotRevision,
 	}
 }
 
-// AddRead records a read operation on a key at a specific revision
-func (t *TxnMeta) AddRead(key string) {
-	t.ReadSet[key] = true
+// AddRead records a read of a point key, along with the mod_revision that was
+// observed for that key at snapshot time (0 if the key did not exist).
+func (t *TxnMeta) AddRead(key string, modRevision Revision) {
+	t.ReadSet[key] = modRevision
 }
 
 // AddWrite records a write operation on a key
@@ -48,7 +60,9 @@ func (t *TxnMeta) AddWrite(key string) {
 	t.WriteSet[key] = true
 }
 
-// AddList records a list-read operation
+// AddList records a list-read operation. Per-key validation cannot reason
+// about phantoms in a range, so we flag the transaction to fall back to the
+// conservative whole-snapshot conflict check at commit time.
 func (t *TxnMeta) AddList(readRange *etcdserverpb.RangeRequest) {
-	klog.Warningf("AddList is not implemented")
+	t.HasRangeRead = true
 }

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -312,7 +312,14 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 
 		existingRevision, hasExisting := m.revisions.GetLatestRevisionByKey(key, snapshotTimestamp)
 
-		txn.meta.AddRead(string(key))
+		// Record the mod_revision we observed for this key so that batch
+		// commit can validate it per-key rather than against the whole
+		// keyspace. A key that does not exist is recorded as revision 0.
+		readRevision := Revision(0)
+		if hasExisting {
+			readRevision = existingRevision
+		}
+		txn.meta.AddRead(string(key), readRevision)
 
 		var prevEvent *mvccpb.Event
 		if hasExisting {
@@ -419,7 +426,12 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 				if err != nil {
 					return nil, err
 				}
-				txn.meta.AddRead(string(op.GetRequestRange().Key))
+				rangeKey := op.GetRequestRange().Key
+				readRevision := Revision(0)
+				if rev, ok := m.revisions.GetLatestRevisionByKey(rangeKey, snapshotTimestamp); ok {
+					readRevision = rev
+				}
+				txn.meta.AddRead(string(rangeKey), readRevision)
 			} else {
 				rangeResp, err = txn.list(ctx, op.GetRequestRange())
 				if err != nil {


### PR DESCRIPTION
## Summary

Replaces the coarse, whole-transaction snapshot check in batch-commit conflict detection with **per-key backward validation**. A write transaction now aborts only when a key it actually **read** (or writes) was changed by a concurrently-committed transaction — not whenever the global revision happens to move.

Previously, two transactions with completely disjoint read/write sets would falsely abort each other whenever they were validated in different batches (`SnapshotRevision != lastLogPosition`). This is exactly the high-frequency, disjoint-key write pattern of the Kubernetes workload (node `Lease` heartbeats, pod status, events, endpoints), so those false aborts forced needless kube-apiserver write retries.

### What changed
- **`TxnMeta`** (`pkg/persistence/txn_meta.go`): `ReadSet` is now `map[string]Revision`, carrying the `mod_revision` observed for each read key (already computed in memorystorage and previously discarded). `AddRead(key, modRevision)` replaces `AddRead(key)`. `AddList` now records that a range read occurred (`HasRangeRead`) instead of being a no-op stub.
- **Batching layer** (`pkg/persistence/batch/`): maintains a per-key write history (`committedWrites`, accessed only under the flush lock). At flush, `validateTxn` commits a transaction iff every read key still holds its observed version **and** no written key changed since the transaction's snapshot. Batch co-scheduling (`CanBatchTogether`) is unchanged.
- **Range-read fallback**: any transaction that performed a range/list read stays on the conservative whole-snapshot check, since per-key validation cannot reason about phantoms. Kubernetes never combines a range read with a write in the same etcd transaction, so this fallback is not expected to fire for the kube workload.
- **memorystorage** (`pkg/storage/memorystorage/memory.go`): plumbs the observed `mod_revision` into `AddRead` at both the `Compare` and point-`Get` sites.

### Notes on the design
This is a **throughput/concurrency** improvement, not a correctness change: the model remains serializable, just no longer needlessly pessimistic. For the point-read workload here, per-key read-version validation is both sufficient and complete (no range/predicate phantom handling needed), matching etcd's native `If(ModRevision(key) == rev)` model.

## Test plan
- New regression test `TestLog_BatchCommit_DisjointKeysNoFalseAbort`: disjoint-key writers validated across separate batches (stale snapshots) must **all** commit — this fails under the old coarse check and passes now.
- Existing `BatchCommit` / `BatchCommit_ReadWriteConflicts` conflict tests still pass (write-write and cyclic read-write conflicts still abort exactly one txn).
- Hand-built `TxnMeta` in `TestLog_BasicOperations` updated to declare its write set, as real transactions do.
- [x] ap-verify-generate / ap-lint / ap-test / ap-e2e all pass locally.

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)