### PR TITLE
gcslog: claim revisions with a DoesNotExist write precondition

### DIFF
--- a/pkg/persistence/gcslog/fencing_test.go
+++ b/pkg/persistence/gcslog/fencing_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcslog
+
+import (
+	"errors"
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+
+	"justinsb.com/cloudetcd/pkg/persistence"
+	"justinsb.com/cloudetcd/pkg/persistence/logtests"
+)
+
+func putRecord(key, value string) *persistence.LogRecord {
+	return &persistence.LogRecord{
+		Events: []*mvccpb.Event{
+			{
+				Type: mvccpb.PUT,
+				Kv: &mvccpb.KeyValue{
+					Key:   []byte(key),
+					Value: []byte(value),
+				},
+			},
+		},
+	}
+}
+
+// TestGCSLogFencing verifies that log object creation is the commit point:
+// when two writers share a bucket/prefix, the second writer to claim a
+// revision must fail with ErrRevisionConflict rather than silently
+// overwriting the first writer's committed batch.
+func TestGCSLogFencing(t *testing.T) {
+	bucketName := "cloudetcd-test"
+	startEmulator(t, bucketName)
+
+	ctx := t.Context()
+	prefix := "fencing/"
+
+	// Two instances sharing the same bucket/prefix, both starting at revision 0.
+	log1, err := NewGCSLog(ctx, bucketName, prefix)
+	if err != nil {
+		t.Fatalf("creating log1: %v", err)
+	}
+	defer log1.Close()
+
+	log2, err := NewGCSLog(ctx, bucketName, prefix)
+	if err != nil {
+		t.Fatalf("creating log2: %v", err)
+	}
+	defer log2.Close()
+
+	// log2 wins the race for revision 1.
+	winnerMeta := logtests.NewTxnMeta(0)
+	winnerMeta.AddWrite("contested")
+	rev, ok, err := log2.Append(ctx, putRecord("contested", "winner"), winnerMeta)
+	if err != nil || !ok {
+		t.Fatalf("winner append failed: ok=%v, err=%v", ok, err)
+	}
+	if rev != 1 {
+		t.Fatalf("winner append: got revision %d, want 1", rev)
+	}
+
+	// log1 doesn't know, and tries to claim revision 1 as well.
+	loserMeta := logtests.NewTxnMeta(0)
+	loserMeta.AddWrite("contested")
+	_, ok, err = log1.Append(ctx, putRecord("contested", "loser"), loserMeta)
+	if ok {
+		t.Fatalf("loser append reported success; it should have lost the race")
+	}
+	if !errors.Is(err, persistence.ErrRevisionConflict) {
+		t.Fatalf("loser append: got error %v, want persistence.ErrRevisionConflict", err)
+	}
+
+	// The loser's local state must not have advanced.
+	currentRev, err := log1.GetCurrentRevision(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentRevision: %v", err)
+	}
+	if currentRev != 0 {
+		t.Errorf("loser's current revision advanced to %d, want 0", currentRev)
+	}
+
+	// The winner's committed batch must be intact: a fresh replay of the log
+	// sees the winner's record at revision 1.
+	log3, err := NewGCSLog(ctx, bucketName, prefix)
+	if err != nil {
+		t.Fatalf("creating log3: %v", err)
+	}
+	defer log3.Close()
+
+	record, err := log3.GetLogEntry(1)
+	if err != nil {
+		t.Fatalf("reading revision 1 after replay: %v", err)
+	}
+	if len(record.Events) != 1 || string(record.Events[0].Kv.Value) != "winner" {
+		t.Errorf("revision 1 after replay: got %+v, want the winner's record", record)
+	}
+}

--- a/pkg/persistence/gcslog/gcs_log.go
+++ b/pkg/persistence/gcslog/gcs_log.go
@@ -17,8 +17,10 @@ package gcslog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"slices"
 	"strconv"
@@ -30,10 +32,13 @@ import (
 	"github.com/justinsb/identityctl/pkg/workloadidentity"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"justinsb.com/cloudetcd/pkg/persistence"
 	"justinsb.com/cloudetcd/pkg/persistence/batch"
 	"k8s.io/klog/v2"
@@ -69,6 +74,30 @@ var _ persistence.BatchAppender = &GCSLog{}
 
 type persistedBatch struct {
 	Records []*persistence.LogRecord
+}
+
+// wrapWriteError converts a failed log-object write into an error for the
+// batching layer. A precondition failure means another writer claimed this
+// revision first; we surface that as persistence.ErrRevisionConflict so it is
+// distinguishable from transient write errors. Because our view of the log is
+// stale, subsequent appends from this instance will keep failing the same
+// way; re-reading the log (today: restarting the process) is required to make
+// progress. Crucially, the other writer's committed batch is untouched.
+func wrapWriteError(objectName string, err error) error {
+	if isPreconditionFailed(err) {
+		return fmt.Errorf("log object %s was created by another writer: %w", objectName, persistence.ErrRevisionConflict)
+	}
+	return fmt.Errorf("failed to write log object %s to GCS: %w", objectName, err)
+}
+
+// isPreconditionFailed reports whether err is a GCS precondition failure
+// (HTTP 412 from the JSON API, FailedPrecondition from the gRPC API).
+func isPreconditionFailed(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed {
+		return true
+	}
+	return status.Code(err) == codes.FailedPrecondition
 }
 
 // newStorageClient creates a GCS client. We prefer the gRPC client, but
@@ -261,9 +290,12 @@ func (l *GCSLog) commitBatch(ctx context.Context, lastLogPosition Revision, batc
 	startRevision := l.lastRevision + 1
 	count := len(batch.Transactions)
 
-	// Create object name with hex-encoded revision
+	// Create object name with hex-encoded revision.
+	// The DoesNotExist precondition makes object creation the commit point:
+	// if another writer has already claimed this revision, the write fails
+	// with a precondition error instead of silently overwriting their batch.
 	objectName := l.batchToObjectName(startRevision, count)
-	obj := l.bucket.Object(objectName)
+	obj := l.bucket.Object(objectName).If(storage.Conditions{DoesNotExist: true})
 
 	// Serialize record to JSON
 	// TODO: Use proto for speed
@@ -285,11 +317,11 @@ func (l *GCSLog) commitBatch(ctx context.Context, lastLogPosition Revision, batc
 
 	if _, err := writer.Write(b); err != nil {
 		writer.Close()
-		return fmt.Errorf("failed to write log record to GCS: %w", err)
+		return wrapWriteError(objectName, err)
 	}
 
 	if err := writer.Close(); err != nil {
-		return fmt.Errorf("failed to close GCS writer: %w", err)
+		return wrapWriteError(objectName, err)
 	}
 
 	l.logFiles = append(l.logFiles, logFileMeta{firstRevision: startRevision, count: count})

--- a/pkg/persistence/log.go
+++ b/pkg/persistence/log.go
@@ -16,11 +16,19 @@ package persistence
 
 import (
 	"context"
+	"errors"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 )
 
 type Revision uint64
+
+// ErrRevisionConflict indicates that an append lost a race with another
+// writer: the storage slot for the revision we tried to claim was already
+// taken. Our view of the log is stale — nothing was overwritten, and no
+// acknowledged write was lost, but this writer must re-read the log before
+// it can append again.
+var ErrRevisionConflict = errors.New("log revision already claimed by another writer")
 
 // LogRecord represents a single entry in the log
 type LogRecord struct {


### PR DESCRIPTION
Fixes #22

## What

Log object creation is now the commit point, as the architecture doc describes. `commitBatch` writes each batch with `.If(storage.Conditions{DoesNotExist: true})` (`ifGenerationMatch=0`), so a writer that lost a race for a revision gets a precondition failure instead of silently overwriting the winner's committed batch.

- Precondition failures (HTTP 412 from the JSON API, `FailedPrecondition` from gRPC) are surfaced as a new sentinel, `persistence.ErrRevisionConflict`, distinct from transient write errors.
- The losing writer's in-memory index (`logFiles`, `lastRevision`, cache) is untouched, and its transactions fail cleanly through the batching layer.
- **Design choice:** on conflict this writer does *not* re-sync and continue. Its materialized storage and OCC write-sets are stale relative to the foreign write, so continuing would serve wrong data; instead every subsequent append keeps failing loudly with `ErrRevisionConflict` until the log is re-read (today: process restart). Fail-stop over fail-operational, since multi-writer isn't supported yet.
- The tiered log's archive drain needs no changes: `Flush` already logs the error and retries next interval, and unarchived records remain in the fast tier, so a concurrent archiver now produces repeated loud errors instead of silent overwrites.

## Testing

- New `TestGCSLogFencing` races two `GCSLog` instances on one bucket/prefix against the in-process objectstorage emulator (which enforces `ifGenerationMatch=0`): the loser must return `ErrRevisionConflict` with `ok=false`, its current revision must not advance, and a fresh replay must still see the winner's record.
- The full emulator suite (`TestGCSLogWithEmulator`) passes with the precondition on, run 3x for flakes.
- `ap generate` / `ap lint` / `ap e2e` green. `ap test` hit one failure: the known pre-existing `TestMemoryStorage_Watch` teardown flake (reproduces identically without this diff; flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)