### PR TITLE
Fix flaky TestMemoryStorage_Watch teardown panic

### DIFF
--- a/pkg/storage/memorystorage/storage_test.go
+++ b/pkg/storage/memorystorage/storage_test.go
@@ -15,6 +15,8 @@
 package memorystorage
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -481,10 +483,18 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		defer watcher.Close()
-
+		// Run the watcher, joining the goroutine before the subtest returns:
+		// otherwise Run can lose the teardown race between watcher.Close and
+		// the cancellation of the parent test's context, return
+		// context.Canceled, and log to t after the subtest has completed,
+		// which panics the test binary.
+		runDone := make(chan error, 1)
 		go func() {
-			if err := watcher.Run(ctx); err != nil {
+			runDone <- watcher.Run(ctx)
+		}()
+		defer func() {
+			watcher.Close()
+			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()
@@ -579,10 +589,18 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		defer watcher.Close()
-
+		// Run the watcher, joining the goroutine before the subtest returns:
+		// otherwise Run can lose the teardown race between watcher.Close and
+		// the cancellation of the parent test's context, return
+		// context.Canceled, and log to t after the subtest has completed,
+		// which panics the test binary.
+		runDone := make(chan error, 1)
 		go func() {
-			if err := watcher.Run(ctx); err != nil {
+			runDone <- watcher.Run(ctx)
+		}()
+		defer func() {
+			watcher.Close()
+			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()


### PR DESCRIPTION
## Problem

`TestMemoryStorage_Watch` panicked roughly once in ten runs:

```
panic: Log in goroutine after TestMemoryStorage_Watch/Storage_Prefix_Watch has completed: watch stopped with error: context canceled
```

Both watch subtests ran `watcher.Run(ctx)` in an unjoined goroutine that reported any error via `t.Errorf`. `Run` checks `ctx.Err()` before the `closed` flag, so when the last subtest's deferred `Close()` raced with the parent test function returning (which cancels `t.Context()`), `Run` could observe the cancellation first, return `context.Canceled`, and the goroutine would log to `t` after the subtest had completed.

## Fix

Join the `Run` goroutine before each subtest returns (a `runDone` channel drained in the deferred cleanup, after `Close()`), and treat `context.Canceled` as expected shutdown rather than a test failure. `Close()` broadcasts the state cond, so the join cannot hang.

## Testing

- Before: `go test ./pkg/storage/memorystorage/ -run TestMemoryStorage_Watch -count=10` reproduced the panic reliably.
- After: 30 consecutive runs clean, plus the full package 3x and 5x under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)