### PR TITLE
gcslog: route storage client metrics to an OTLP collector, or disable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/api/v3 v3.7.0
 	go.etcd.io/etcd/client/v3 v3.7.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	google.golang.org/api v0.289.0
 	google.golang.org/grpc v1.82.1
 	k8s.io/api v0.36.2
@@ -31,6 +33,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
@@ -76,8 +79,8 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.57.0/go.mod h1:dzcEjy1WJ0Q4u9twNR3LcLhNoYMRCrMCMafpxa0TjPQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 h1:RoO5+d7uCmDqovLrHCr2/BuViUXvdcrNxyNM1pN9dDQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0/go.mod h1:YqwkQPrWSC7+byyc1VlKbWLBF5JsW5IoL6xUkemYSXk=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
@@ -166,6 +168,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0/go.mod h1:ho2g4N+ane+swq5I/VBkKWnRDY4kUINH3FuqyZqX/Ug=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 h1:hqxVTu/GtBF+vJ8d1fzW7fRxZFvgoDjWcxwwCaFDYpU=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0/go.mod h1:z5fVEF4X5v0ESvlJqBrrFlBVoj5EQuefZpzsu7R+x5Q=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
@@ -178,6 +182,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/pkg/persistence/gcslog/gcs_log.go
+++ b/pkg/persistence/gcslog/gcs_log.go
@@ -26,9 +26,14 @@ import (
 	"sync"
 
 	"cloud.google.com/go/storage"
+	"cloud.google.com/go/storage/experimental"
 	"github.com/justinsb/identityctl/pkg/workloadidentity"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"justinsb.com/cloudetcd/pkg/persistence"
 	"justinsb.com/cloudetcd/pkg/persistence/batch"
 	"k8s.io/klog/v2"
@@ -83,7 +88,55 @@ func newStorageClient(ctx context.Context) (*storage.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building GCP token source: %w", err)
 	}
-	return storage.NewGRPCClient(ctx, option.WithTokenSource(tokenSource))
+	opts := []option.ClientOption{option.WithTokenSource(tokenSource)}
+	metricsOpts, err := metricsClientOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, metricsOpts...)
+	return storage.NewGRPCClient(ctx, opts...)
+}
+
+// metricsClientOptions configures where the storage client's client-side
+// metrics go. By default the client exports them to Cloud Monitoring, which
+// requires a project ID it cannot discover from federated credentials or on
+// non-GCP nodes. So: if an OTLP endpoint is configured via the standard
+// OTEL_EXPORTER_OTLP_METRICS_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT
+// environment variables, metrics are exported there (an in-cluster
+// collector; unix:///path endpoints are supported for collectors listening
+// on a Unix domain socket); otherwise client-side metrics are disabled.
+func metricsClientOptions(ctx context.Context) ([]option.ClientOption, error) {
+	log := klog.FromContext(ctx)
+
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if endpoint == "" {
+		return []option.ClientOption{storage.WithDisabledClientMetrics()}, nil
+	}
+
+	var otlpExporter sdkmetric.Exporter
+	if strings.HasPrefix(endpoint, "unix:") {
+		conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, fmt.Errorf("dialing OTLP collector %q: %w", endpoint, err)
+		}
+		otlpExporter, err = otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
+		if err != nil {
+			return nil, fmt.Errorf("building OTLP metric exporter for %q: %w", endpoint, err)
+		}
+	} else {
+		// otlpmetricgrpc reads the standard OTEL_EXPORTER_OTLP_* environment
+		// variables itself (an http:// scheme implies an insecure connection).
+		var err error
+		otlpExporter, err = otlpmetricgrpc.New(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("building OTLP metric exporter for %q: %w", endpoint, err)
+		}
+	}
+	log.Info("exporting storage client metrics via OTLP", "endpoint", endpoint)
+	return []option.ClientOption{experimental.WithMetricExporter(&otlpExporter)}, nil
 }
 
 // NewGCSLog creates a new Google Cloud Storage-backed log

--- a/pkg/persistence/gcslog/metrics_test.go
+++ b/pkg/persistence/gcslog/metrics_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcslog
+
+import (
+	"testing"
+)
+
+func TestMetricsClientOptions(t *testing.T) {
+	grid := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "unset disables client metrics", endpoint: ""},
+		{name: "tcp collector endpoint", endpoint: "http://collector.observability.svc:4317"},
+		{name: "unix domain socket endpoint", endpoint: "unix:///run/collector/otlp.sock"},
+	}
+	for _, testCase := range grid {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", testCase.endpoint)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			opts, err := metricsClientOptions(t.Context())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(opts) != 1 {
+				t.Fatalf("expected exactly one client option, got %d", len(opts))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The gRPC storage client exports client-side metrics to Cloud Monitoring by default, which needs a project ID it cannot discover from federated credentials or on non-GCP nodes, producing a warning at startup. If the standard OTEL_EXPORTER_OTLP_METRICS_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT environment variables are set, metrics now go to that collector instead (unix:///path endpoints supported for UDS collectors); with no endpoint configured, client-side metrics are disabled cleanly.