### PR TITLE
versionbump: go 1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The project is in early development. Currently implemented:
 
 ### Prerequisites
 
-- Go 1.24 or later
+- Go 1.27 or later
 
 ### Running Tests
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module justinsb.com/cloudetcd
 
-go 1.26.4
-
-toolchain go1.26.5
+go 1.27.0
 
 require (
 	cloud.google.com/go/storage v1.63.1


### PR DESCRIPTION
## Summary

Update to Go 1.27.0 (current latest) to clear the `ap-lint` govulncheck failure, which flags four standard-library vulnerabilities in go1.26.5 (GO-2026-5972 `encoding/asn1`, GO-2026-5026 `net/http`, two in `crypto/tls`), all fixed in go1.26.6+.

- `go.mod`: `go 1.27.0`; the `toolchain` directive is removed as redundant (`go mod tidy`).
- `README.md`: prerequisite is now Go 1.27.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` on go1.27.0
- [x] `govulncheck ./...`: 0 vulnerabilities in called code (was 4)

Note: `ap-verify-generate` fails independently on `main`; #40 fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
