### PR TITLE
memorystorage: commit transactions optimistically so the log can batch them

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -532,10 +532,14 @@ func (ws *watchStream) handleProgressRequest(ctx context.Context, req *etcdserve
 func (ws *watchStream) cleanup(closeGRPC bool) {
 	// TODO: Send cancellation events to all watches?
 
+	// handleCancelRequest may still be deleting from the map on the request
+	// goroutine when the stream's context ends.
+	ws.mu.Lock()
 	for _, watch := range ws.watches {
 		watch.close()
 	}
 	ws.watches = make(map[int64]*activeWatch)
+	ws.mu.Unlock()
 
 	if closeGRPC {
 		ws.cancel()

--- a/pkg/persistence/batch/batch.go
+++ b/pkg/persistence/batch/batch.go
@@ -164,11 +164,17 @@ func (b *TxnBatch) flush(ctx context.Context, lastLogPosition Revision) (int, er
 		}
 
 		revision++
+		// Transactions stamp their events with snapshot+1; with several
+		// transactions per batch (or concurrent batches) the committed
+		// revision differs, so re-stamp every event here.
 		for _, event := range txn.LogRecord.Events {
-			if event.Type == mvccpb.PUT {
+			switch event.Type {
+			case mvccpb.PUT:
 				if event.Kv.CreateRevision == event.Kv.ModRevision {
 					event.Kv.CreateRevision = int64(revision)
 				}
+				event.Kv.ModRevision = int64(revision)
+			case mvccpb.DELETE:
 				event.Kv.ModRevision = int64(revision)
 			}
 		}

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memorystorage
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+
+	"justinsb.com/cloudetcd/pkg/persistence/memorylog"
+)
+
+// TestConcurrentConditionalUpdatesSerialize races N compare-and-put
+// transactions on one key that all observed the same mod_revision. Exactly
+// one must succeed; the rest must fail their compare (Succeeded=false, with
+// the Else Range showing the winner's value) rather than error or overwrite.
+func TestConcurrentConditionalUpdatesSerialize(t *testing.T) {
+	ctx := t.Context()
+	// A commit latency makes the batching window wide enough that the racing
+	// transactions land in the same batch, which is the case that matters.
+	store, err := NewMemoryStorage(memorylog.New(memorylog.WithCommitLatency(20 * time.Millisecond)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := []byte("/registry/leases/kube-node-lease/node-1")
+	putResp, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: key, Value: []byte("v0")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rev := putResp.Header.Revision
+
+	const racers = 32
+	var wg sync.WaitGroup
+	results := make([]*etcdserverpb.TxnResponse, racers)
+	errs := make([]error, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = store.Txn(ctx, &etcdserverpb.TxnRequest{
+				Compare: []*etcdserverpb.Compare{{
+					Key:         key,
+					Target:      etcdserverpb.Compare_MOD,
+					Result:      etcdserverpb.Compare_EQUAL,
+					TargetUnion: &etcdserverpb.Compare_ModRevision{ModRevision: rev},
+				}},
+				Success: []*etcdserverpb.RequestOp{{Request: &etcdserverpb.RequestOp_RequestPut{
+					RequestPut: &etcdserverpb.PutRequest{Key: key, Value: []byte(fmt.Sprintf("racer-%d", i))}}}},
+				Failure: []*etcdserverpb.RequestOp{{Request: &etcdserverpb.RequestOp_RequestRange{
+					RequestRange: &etcdserverpb.RangeRequest{Key: key}}}},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	var winnerValue string
+	for i := range results {
+		if errs[i] != nil {
+			t.Fatalf("racer %d: %v", i, errs[i])
+		}
+		if results[i].Succeeded {
+			winners++
+			winnerValue = fmt.Sprintf("racer-%d", i)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("%d racers succeeded, want exactly 1", winners)
+	}
+	for i, r := range results {
+		if r.Succeeded {
+			continue
+		}
+		kvs := r.Responses[0].GetResponseRange().Kvs
+		if len(kvs) != 1 || string(kvs[0].Value) != winnerValue {
+			t.Errorf("racer %d: else-branch read %q, want the winner's %q", i, kvs, winnerValue)
+		}
+	}
+	got, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Kvs[0].Value) != winnerValue || got.Kvs[0].ModRevision != rev+1 || got.Kvs[0].Version != 2 {
+		t.Errorf("final state %v, want value %q at mod_revision %d version 2", got.Kvs[0], winnerValue, rev+1)
+	}
+}
+
+// TestConcurrentWritesToDistinctKeys races puts on distinct keys. All must
+// succeed, be assigned distinct contiguous revisions, and be readable at the
+// revision each response reported, with the log and index agreeing.
+func TestConcurrentWritesToDistinctKeys(t *testing.T) {
+	ctx := t.Context()
+	store, err := NewMemoryStorage(memorylog.New(memorylog.WithCommitLatency(20 * time.Millisecond)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := store.GetCurrentRevision(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const writers = 64
+	revs := make([]int64, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("/registry/minions/node-%03d", i)
+			// Create, then a conditional update on the revision we were told.
+			resp, err := store.Txn(ctx, &etcdserverpb.TxnRequest{
+				Compare: []*etcdserverpb.Compare{{Key: []byte(key), Target: etcdserverpb.Compare_MOD, Result: etcdserverpb.Compare_EQUAL,
+					TargetUnion: &etcdserverpb.Compare_ModRevision{ModRevision: 0}}},
+				Success: []*etcdserverpb.RequestOp{{Request: &etcdserverpb.RequestOp_RequestPut{
+					RequestPut: &etcdserverpb.PutRequest{Key: []byte(key), Value: []byte("a")}}}},
+			})
+			if err != nil || !resp.Succeeded {
+				t.Errorf("create %s: succeeded=%v err=%v", key, resp.GetSucceeded(), err)
+				return
+			}
+			resp, err = store.Txn(ctx, &etcdserverpb.TxnRequest{
+				Compare: []*etcdserverpb.Compare{{Key: []byte(key), Target: etcdserverpb.Compare_MOD, Result: etcdserverpb.Compare_EQUAL,
+					TargetUnion: &etcdserverpb.Compare_ModRevision{ModRevision: resp.Header.Revision}}},
+				Success: []*etcdserverpb.RequestOp{{Request: &etcdserverpb.RequestOp_RequestPut{
+					RequestPut: &etcdserverpb.PutRequest{Key: []byte(key), Value: []byte("b")}}}},
+			})
+			if err != nil || !resp.Succeeded {
+				t.Errorf("update %s: succeeded=%v err=%v", key, resp.GetSucceeded(), err)
+				return
+			}
+			revs[i] = resp.Header.Revision
+			// Our write must be visible to a read at the revision we were told.
+			got, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte(key), Revision: resp.Header.Revision})
+			if err != nil || len(got.Kvs) != 1 || string(got.Kvs[0].Value) != "b" || got.Kvs[0].Version != 2 {
+				t.Errorf("read-your-write %s at %d: %v err=%v", key, resp.Header.Revision, got.GetKvs(), err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if t.Failed() {
+		return
+	}
+
+	// 2 writes per writer, contiguous after base, no duplicates.
+	current, err := store.GetCurrentRevision(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(current-base) != 2*writers {
+		t.Errorf("revision advanced by %d, want %d", current-base, 2*writers)
+	}
+	sort.Slice(revs, func(i, j int) bool { return revs[i] < revs[j] })
+	for i := 1; i < len(revs); i++ {
+		if revs[i] == revs[i-1] {
+			t.Errorf("duplicate revision %d", revs[i])
+		}
+	}
+
+	// The index agrees with the log: every key is present with version 2 at
+	// its own mod_revision, and a list at the head sees all of them.
+	list, err := store.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/registry/minions/"), RangeEnd: []byte("/registry/minions0")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Kvs) != writers {
+		t.Fatalf("list saw %d keys, want %d", len(list.Kvs), writers)
+	}
+	for _, kv := range list.Kvs {
+		if kv.Version != 2 || string(kv.Value) != "b" {
+			t.Errorf("%s: version %d value %q", kv.Key, kv.Version, kv.Value)
+		}
+	}
+}

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -39,6 +39,12 @@ type MemoryStorage struct {
 
 	revisions bptree.BPTree
 
+	// applied is the highest log revision whose events have been applied to
+	// revisions (and the lease manager). Records are committed by the log's
+	// batching layer, possibly many per batch, and applied here in log order
+	// by applyUpTo; guarded by mu.
+	applied Revision
+
 	log persistence.Log // Persistence log
 
 	watcherMu sync.RWMutex
@@ -95,6 +101,7 @@ func (m *MemoryStorage) ReplayLog(ctx context.Context) error {
 		if newRevision != 1 {
 			return fmt.Errorf("expected revision 1, got %d", newRevision)
 		}
+		m.applied = newRevision
 		return nil
 	}
 
@@ -125,7 +132,45 @@ func (m *MemoryStorage) ReplayLog(ctx context.Context) error {
 	if err := m.log.Read(ctx, 1, callback); err != nil {
 		return fmt.Errorf("failed to read log records: %w", err)
 	}
+	m.applied = currentRevision
 
+	return nil
+}
+
+// applyUpTo applies every committed log record up to and including rev to
+// the index, in log order. Any goroutine may call it: a transaction after its
+// append returns, or a reader before it evaluates at a snapshot, so that the
+// index always reflects the revision a caller is about to read at, no matter
+// which goroutine's append happened to commit it.
+func (m *MemoryStorage) applyUpTo(ctx context.Context, rev Revision) error {
+	m.mu.RLock()
+	applied := m.applied
+	m.mu.RUnlock()
+	if applied >= rev {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for r := m.applied + 1; r <= rev; r++ {
+		record, err := m.log.GetLogEntry(r)
+		if err != nil {
+			return fmt.Errorf("reading log record %d: %w", r, err)
+		}
+		if record == nil {
+			return fmt.Errorf("log record %d not found", r)
+		}
+		for _, event := range record.Events {
+			switch event.Type {
+			case mvccpb.PUT, mvccpb.DELETE:
+				m.revisions.AddRevision(event.Kv.Key, r)
+			default:
+				klog.Fatalf("unknown operation: %s", event.Type)
+			}
+			m.leaseManager.OnLogEvent(event)
+		}
+		m.applied = r
+	}
 	return nil
 }
 
@@ -231,11 +276,15 @@ func (t *txn) put(ctx context.Context, req *etcdserverpb.PutRequest) (*etcdserve
 	return response, nil
 }
 
-func (t *txn) commit(ctx context.Context, resp *etcdserverpb.TxnResponse) error {
+// commit appends the transaction's events to the log. It returns false (and
+// no error) if the batching layer rejected the transaction because a key it
+// read or wrote was committed by another transaction after its snapshot; the
+// caller re-evaluates at a fresh snapshot.
+func (t *txn) commit(ctx context.Context, resp *etcdserverpb.TxnResponse) (bool, error) {
 	log := klog.FromContext(ctx)
 
 	if len(t.logEvents) == 0 {
-		return nil
+		return true, nil
 	}
 
 	// Let's see if we can commit this transaction without conflicts
@@ -247,26 +296,17 @@ func (t *txn) commit(ctx context.Context, resp *etcdserverpb.TxnResponse) error 
 	}
 
 	newLogRevision, ok, err := t.storage.log.Append(ctx, logRecord, t.meta)
-	if err != nil || !ok {
-		return fmt.Errorf("failed to append to log: %w", err)
+	if err != nil {
+		return false, fmt.Errorf("failed to append to log: %w", err)
+	}
+	if !ok {
+		return false, nil
 	}
 
-	// TODO: Can we reuse replay?
-
-	for _, event := range logRecord.Events {
-		switch event.Type {
-		case mvccpb.PUT:
-			t.storage.revisions.AddRevision(event.Kv.Key, newLogRevision)
-
-		case mvccpb.DELETE:
-			t.storage.revisions.AddRevision(event.Kv.Key, newLogRevision)
-
-		default:
-			// Skip unknown operations
-			klog.Fatalf("unknown operation: %s", event.Type)
-		}
-
-		t.storage.leaseManager.OnLogEvent(event)
+	// The batch may have committed other transactions ahead of ours; apply
+	// everything up to our revision so the response is visible to reads.
+	if err := t.storage.applyUpTo(ctx, newLogRevision); err != nil {
+		return false, err
 	}
 
 	resp.Header.Revision = int64(newLogRevision)
@@ -283,23 +323,69 @@ func (t *txn) commit(ctx context.Context, resp *etcdserverpb.TxnResponse) error 
 			response.ResponseRange.Header = resp.Header
 
 		default:
-			return fmt.Errorf("unsupported response type: %T", response)
+			return false, fmt.Errorf("unsupported response type: %T", response)
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
-// Txn executes a transaction against the storage.
-func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// maxTxnAttempts bounds how many times a transaction is re-evaluated after
+// losing optimistic validation. Kubernetes transactions touch one key each,
+// so a retry only happens when that key was concurrently written, and the
+// re-evaluation then fails the compare rather than conflicting again.
+const maxTxnAttempts = 64
 
+// Txn executes a transaction against the storage.
+//
+// Transactions run optimistically: each is evaluated at a snapshot under a
+// read lock, its events are appended to the log without any storage lock held
+// (so the log's batching layer can commit many transactions per write to the
+// backend), and the batching layer validates per key that nothing the
+// transaction read or wrote was committed after its snapshot. A transaction
+// that loses that validation is re-evaluated at a fresh snapshot, where its
+// compares see the concurrent write.
+func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
+	for attempt := 0; attempt < maxTxnAttempts; attempt++ {
+		resp, committed, err := m.tryTxn(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		if committed {
+			return resp, nil
+		}
+	}
+	return nil, fmt.Errorf("transaction conflicted with concurrent writes %d times", maxTxnAttempts)
+}
+
+func (m *MemoryStorage) tryTxn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, bool, error) {
 	snapshotTimestamp, err := m.log.GetCurrentRevision(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current revision: %w", err)
+		return nil, false, fmt.Errorf("failed to get current revision: %w", err)
+	}
+	// The log may have committed records that no goroutine has applied yet.
+	if err := m.applyUpTo(ctx, snapshotTimestamp); err != nil {
+		return nil, false, err
 	}
 
+	resp, txn, err := m.evaluate(ctx, req, snapshotTimestamp)
+	if err != nil {
+		return nil, false, err
+	}
+	committed, err := txn.commit(ctx, resp)
+	if err != nil {
+		return nil, false, err
+	}
+	return resp, committed, nil
+}
+
+// evaluate runs the transaction's compares and operations against the index
+// at snapshotTimestamp, staging its events; nothing is written.
+func (m *MemoryStorage) evaluate(ctx context.Context, req *etcdserverpb.TxnRequest, snapshotTimestamp Revision) (*etcdserverpb.TxnResponse, *txn, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var err error
 	txn := &txn{
 		snapshotTimestamp: snapshotTimestamp,
 		storage:           m,
@@ -344,7 +430,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 
 			targetValue, ok := cond.GetTargetUnion().(*etcdserverpb.Compare_ModRevision)
 			if !ok {
-				return nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
+				return nil, nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
 			}
 
 			switch cond.GetResult() {
@@ -356,7 +442,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 				}
 
 			default:
-				return nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
+				return nil, nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
 			}
 
 		case etcdserverpb.Compare_VERSION:
@@ -369,7 +455,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 
 			targetValue, ok := cond.GetTargetUnion().(*etcdserverpb.Compare_Version)
 			if !ok {
-				return nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
+				return nil, nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
 			}
 
 			switch cond.GetResult() {
@@ -379,7 +465,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 				}
 
 			default:
-				return nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
+				return nil, nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
 			}
 
 		case etcdserverpb.Compare_LEASE:
@@ -392,7 +478,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 
 			targetValue, ok := cond.GetTargetUnion().(*etcdserverpb.Compare_Lease)
 			if !ok {
-				return nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
+				return nil, nil, fmt.Errorf("unsupported target: %T", cond.GetTargetUnion())
 			}
 
 			switch cond.GetResult() {
@@ -403,11 +489,11 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 				}
 
 			default:
-				return nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
+				return nil, nil, fmt.Errorf("unsupported compare result: %s", cond.GetResult())
 			}
 
 		default:
-			return nil, fmt.Errorf("unsupported compare target: %s", cond.GetTarget())
+			return nil, nil, fmt.Errorf("unsupported compare target: %s", cond.GetTarget())
 		}
 	}
 
@@ -427,7 +513,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 			putRequest := op.GetRequestPut()
 			putResp, err := txn.put(ctx, putRequest)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			resp.Responses = append(resp.Responses, &etcdserverpb.ResponseOp{
 				Response: &etcdserverpb.ResponseOp_ResponsePut{ResponsePut: putResp},
@@ -436,7 +522,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 		case *etcdserverpb.RequestOp_RequestDeleteRange:
 			deleteResp, err := txn.delete(ctx, op.GetRequestDeleteRange())
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			resp.Responses = append(resp.Responses, &etcdserverpb.ResponseOp{
 				Response: &etcdserverpb.ResponseOp_ResponseDeleteRange{ResponseDeleteRange: deleteResp},
@@ -447,7 +533,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 			if op.GetRequestRange().GetRangeEnd() == nil {
 				rangeResp, err = txn.get(ctx, op.GetRequestRange())
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				rangeKey := op.GetRequestRange().Key
 				readRevision := Revision(0)
@@ -458,7 +544,7 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 			} else {
 				rangeResp, err = txn.list(ctx, op.GetRequestRange())
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				txn.meta.AddList(op.GetRequestRange())
 			}
@@ -468,15 +554,11 @@ func (m *MemoryStorage) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (
 			})
 
 		default:
-			return nil, fmt.Errorf("unsupported operation: %T", op.Request)
+			return nil, nil, fmt.Errorf("unsupported operation: %T", op.Request)
 		}
 	}
 
-	if err := txn.commit(ctx, resp); err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return resp, txn, nil
 }
 
 type txn struct {
@@ -521,15 +603,9 @@ func (t *txn) get(ctx context.Context, req *etcdserverpb.RangeRequest) (*etcdser
 		return nil, fmt.Errorf("range end is not supported by Get")
 	}
 
-	snapshotTimestamp := Revision(0)
+	snapshotTimestamp := t.snapshotTimestamp
 	if req.Revision > 0 {
 		snapshotTimestamp = Revision(req.Revision)
-	} else {
-		currentRevision, err := m.log.GetCurrentRevision(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current revision: %w", err)
-		}
-		snapshotTimestamp = currentRevision
 	}
 
 	if req.CountOnly {
@@ -776,15 +852,9 @@ func (t *txn) list(ctx context.Context, req *etcdserverpb.RangeRequest) (*etcdse
 		return nil, fmt.Errorf("range end is required by List")
 	}
 
-	snapshotTimestamp := Revision(0)
+	snapshotTimestamp := t.snapshotTimestamp
 	if req.Revision > 0 {
 		snapshotTimestamp = Revision(req.Revision)
-	} else {
-		currentRevision, err := m.log.GetCurrentRevision(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current revision: %w", err)
-		}
-		snapshotTimestamp = currentRevision
 	}
 
 	resp := &etcdserverpb.RangeResponse{
@@ -883,6 +953,7 @@ func (m *MemoryStorage) ForceReplayLog(ctx context.Context) error {
 	// Clear current state
 	m.mu.Lock()
 	m.revisions = bptree.BPTree{}
+	m.applied = 0
 	m.mu.Unlock()
 
 	// Replay the log

--- a/pkg/storage/memorystorage/memory_replay_test.go
+++ b/pkg/storage/memorystorage/memory_replay_test.go
@@ -303,24 +303,21 @@ func TestMemoryStorageFilesystemLogReplay(t *testing.T) {
 		t.Errorf("Expected revision 6, got %d", getRevision(t, resp5))
 	}
 
-	// Step 9: Verify the new data is visible in storage2 but not storage1
-	keysResp, err = storage2.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("aaa"), RangeEnd: []byte("zzz")})
-	if err != nil {
-		t.Fatalf("Failed to list keys in storage2: %v", err)
-	}
-	keys = keysResp.Kvs
-	if len(keys) != 2 {
-		t.Errorf("Expected 2 keys in storage2, got %d", len(keys))
-	}
-
-	// storage1 should still only have the original key
-	keysResp, err = storage1.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("aaa"), RangeEnd: []byte("zzz")})
-	if err != nil {
-		t.Fatalf("Failed to list keys in storage1: %v", err)
-	}
-	keys = keysResp.Kvs
-	if len(keys) != 1 {
-		t.Errorf("Expected 1 key in storage1, got %d", len(keys))
+	// Step 9: Verify the new data is visible in storage2, and in storage1:
+	// both read the shared log at its current revision, and a storage applies
+	// any records committed since it last looked before it reads, so storage1
+	// never returns a header revision it has not caught up to.
+	for name, st := range map[string]*MemoryStorage{"storage1": storage1, "storage2": storage2} {
+		keysResp, err = st.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("aaa"), RangeEnd: []byte("zzz")})
+		if err != nil {
+			t.Fatalf("Failed to list keys in %s: %v", name, err)
+		}
+		if len(keysResp.Kvs) != 2 {
+			t.Errorf("Expected 2 keys in %s, got %d", name, len(keysResp.Kvs))
+		}
+		if keysResp.Header.Revision != 6 {
+			t.Errorf("Expected %s to read at revision 6, got %d", name, keysResp.Header.Revision)
+		}
 	}
 
 	// Test that deleted key is still deleted after replay

--- a/pkg/workload/runner.go
+++ b/pkg/workload/runner.go
@@ -292,10 +292,9 @@ func (r *Runner) Steady(ctx context.Context, d time.Duration) (*Report, error) {
 	if c.ConsistentReadsPerSecond > 0 {
 		interval := time.Duration(float64(time.Second) / c.ConsistentReadsPerSecond)
 		loop(func() {
-			var n int
+			var n atomic.Int64 // jobs run on several workers
 			p.every(interval, func(ctx context.Context) {
-				res := readResources[n%len(readResources)]
-				n++
+				res := readResources[int(n.Add(1)-1)%len(readResources)]
 				_ = r.exec.get(ctx, OpConsistentRead, c.resourceKey(res))
 			})
 		})


### PR DESCRIPTION
## Summary

The stress test (#38) showed cloudetcd doing **one backend write per transaction** regardless of the batching layer: ~96 writes/s in memory, ~17/s at an object store's 50 ms commit latency, with reads queued behind writes. Cause: `MemoryStorage.Txn` held the exclusive storage lock across `log.Append`, which blocks until the batch is flushed — so no second transaction could reach the batcher while the first waited, and every batch had exactly one transaction.

This makes transactions optimistic, which is what the batching layer's per-key read/write-set validation (`5ff3a9b`) was built for:

- **evaluate** compares and ops at a snapshot under a *read* lock, staging events;
- **append** with no storage lock held, so hundreds of transactions share one backend write;
- the batcher **validates** per key that nothing the transaction read or wrote committed after its snapshot; a loser is **re-evaluated** at a fresh snapshot, where its compare observes the concurrent write (so the apiserver sees `Succeeded=false`, exactly as with etcd);
- committed records are **applied to the index in log order** by `applyUpTo`, run by any goroutine — a transaction after its append, and a reader before it evaluates — so a read never returns a header revision the index hasn't caught up to. Reads inside a transaction use the transaction's snapshot rather than re-reading the log head.

Also fixed along the way:
- batcher only re-stamped PUT events with the committed revision; DELETEs kept `snapshot+1` (masked by the old serialization);
- `watchStream.cleanup` iterated `ws.watches` without `ws.mu` while cancel requests deleted from it (race detector, pre-existing);
- the bench's consistent-read round-robin counter is now atomic (race detector).

**Behaviour change:** `TestMemoryStorageFilesystemLogReplay` asserted that two storages sharing one log diverge — storage1 returning header revision 6 with data as of 5 after storage2 wrote. That was a stale read; both now read at the log head, and the test says so.

## Results (`cloud-etcd-bench`, nodes only, 64 workers unless noted)

| cluster | backend | writes needed | before | after |
|---|---|---|---|---|
| 1,000 nodes | 50 ms commit | 100/s | 14/s, lag 37 s ↑, reads 3.8 s | **99.5/s**, lag 1 ms, reads 0.3 ms |
| 1,000 nodes | in-memory | 103/s | 96/s, lag 2 s ↑ | 100/s, lag 1 ms |
| 10,000 nodes | in-memory | 1,033/s | — | **996/s**, 7.8 ms p50, lag < 1 ms |
| 10,000 nodes | 50 ms commit | 1,033/s | — | 940/s (client-bound at 64 in-flight; see below) |
| populate 10k nodes (20k keys) | 50 ms commit | | 16/s → ~21 min | **787/s → 25 s** |

Write latency at 50 ms commit is ~70 ms p50 (commit + 10 ms batching window), i.e. the backend round-trip is now paid per batch, not per write.

## Test plan

- [x] New `TestConcurrentConditionalUpdatesSerialize` (32 racing compare-and-puts on one key → exactly one wins, losers' Else-Range shows the winner) and `TestConcurrentWritesToDistinctKeys` (64 concurrent create+update → contiguous revisions, read-your-write at the reported revision, index matches log), 3× under `-race`
- [x] `go test -race ./pkg/... ./tests/...` clean, except the pre-existing `TestMemoryStorage_Watch` teardown panic (reproduces identically on `main`)
- [x] `go test ./...` 11/11
- [x] `RUN_E2E=1` real kube-apiserver smoke test
- [x] `RUN_STRESS=1` 200 nodes × 5 pods at 50 ms commit latency, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
