### PR TITLE
bptree: make the radix tree split on common prefixes

### DIFF
--- a/pkg/bptree/bptree.go
+++ b/pkg/bptree/bptree.go
@@ -12,249 +12,275 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package bptree implements an in-memory B+ tree.
+// Package bptree implements the in-memory key index: for each key, the list
+// of log revisions at which it was written, ordered by key so that ranges can
+// be scanned.
 //
-// This B+ tree is used as an index for key-based lookups. It does not store
-// values directly, but rather a list of 64-bit revision numbers for each key.
+// The index is a radix (prefix) tree. Each node holds entries sorted by their
+// prefix; sibling entries never share a first byte, so a node has at most 256
+// entries and is searched by binary search on that byte. An entry carries the
+// revisions of the key that ends exactly at it (if any) and a child node for
+// the keys that continue past it (if any). Inserting a key that shares only
+// part of an entry's prefix splits the entry at the common prefix. Kubernetes
+// keys share long prefixes (/registry/pods/<ns>/...), so the tree stores each
+// prefix once, and keys under one prefix are a few small nodes deep rather
+// than one long list.
 //
-// The implementation is designed for in-memory use, and as such does not have
-// strictly balanced pages. It also supports multiple revision numbers for each key.
+// The tree is safe for concurrent readers with a single writer serialized by
+// its own lock; memorystorage additionally serializes writes against reads.
 package bptree
 
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"sort"
 	"sync"
 
 	"justinsb.com/cloudetcd/pkg/persistence"
 )
 
-// BPTree is a B+ tree implementation. It contains a pointer to the root node
-// and a read-write mutex for concurrent access.
-type BPTree struct {
-	// revision atomic.Uint64
-	root node
-}
-
 type Revision = persistence.Revision
 
-// Dump dumps the B+ tree to the console.
-func (t *BPTree) Dump() {
-	t.root.dump()
+// BPTree indexes keys to the revisions at which they were written. The zero
+// value is an empty index.
+type BPTree struct {
+	mu   sync.RWMutex
+	root node
+	// emptyKey holds the revisions of the empty key, which has no first byte
+	// to place it in a node.
+	emptyKey []Revision
+	// keys is the number of distinct keys in the index.
+	keys int
 }
 
-func (n *node) dump() {
-	for _, e := range n.entries {
-		fmt.Printf("prefix: %s, child: %v, revisions: %v\n", e.prefix, e.child != nil, e.revisions)
-	}
-}
-
-// // GetCurrentRevision returns the current revision of the B+ tree.
-// func (t *BPTree) GetCurrentRevision() Revision {
-// 	v := t.revision.Load()
-// 	return Revision(v)
-// }
-
-// AddRevision adds a new revision to a key. If the key does not exist, it is created.
-//
-// The algorithm is as follows:
-//  1. Traverse the tree to find the leaf node where the key should be inserted.
-//  2. If the key already exists, append the new revision to the existing list of revisions.
-//  3. If the key does not exist, insert the key and the new revision into the leaf node.
-//  4. If the leaf node is full, split it into two nodes and promote the middle key to the parent node.
-//     This splitting process may propagate up to the root of the tree.
-func (t *BPTree) AddRevision(key []byte, revision Revision) {
-	t.root.addRevision(key, revision)
-
-	// for {
-	// 	oldRevision := t.revision.Load()
-	// 	if revision <= Revision(oldRevision) {
-	// 		break
-	// 	}
-	// 	if t.revision.CompareAndSwap(oldRevision, uint64(revision)) {
-	// 		break
-	// 	}
-	// }
-}
-
-// GetLatestRevisionByKey returns the latest revision for a key that is less than or equal to the given timestamp.
-//
-// The algorithm is as follows:
-// 1. Traverse the tree to find the leaf node containing the key.
-// 2. If the key is found, iterate through its revisions and return the latest revision that is less than or equal to the given timestamp.
-// 3. If the key is not found, return 0 and false.
-func (t *BPTree) GetLatestRevisionByKey(key []byte, atRevision Revision) (Revision, bool) {
-	return t.root.getLatestRevisionByKey(key, atRevision)
-}
-
-// listRevisionsByKeyRange calls the callback for each key in the given range with its revisions.
-//
-// The algorithm is as follows:
-// 1. Traverse the tree to find the leaf node where the startKey is located.
-// 2. Iterate through the leaf nodes until the endKey is reached.
-// 3. For each key in the range, find all revisions that are less than or equal to the given timestamp and call the callback with the key and revisions.
-func (t *BPTree) ListRevisionsByKeyRange(startKey []byte, atRevision Revision, callback func(key []byte, revisions []Revision) bool) {
-	t.root.listRevisionsByKeyRange(startKey, atRevision, callback)
-}
-
-// node represents a node in the B+ tree. It contains a slice of keys, a slice
-// of values (which are slices of 64-bit integers), and a slice of child nodes.
+// node holds entries sorted by prefix; no two entries share a first byte.
 type node struct {
-	mutex sync.RWMutex
-
 	entries []nodeEntry
 }
 
+// nodeEntry is one edge of the tree: prefix is the key bytes it covers
+// (relative to its parent), revisions those of the key ending exactly here
+// (nil if no key does), and child the node for keys continuing past it (nil
+// if none do).
 type nodeEntry struct {
 	prefix    []byte
-	child     *node
 	revisions []Revision
+	child     *node
 }
 
-func (n *node) addRevision(remainingKey []byte, revision Revision) {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
+// Dump prints the index, for debugging.
+func (t *BPTree) Dump() {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.emptyKey != nil {
+		fmt.Printf("key: (empty), revisions: %v\n", t.emptyKey)
+	}
+	t.root.dump(nil)
+}
 
-	pos, match := n.findEntry(remainingKey)
-	if match {
-		e := &n.entries[pos]
-		if len(e.prefix) == len(remainingKey) {
-			e.revisions = append(e.revisions, revision)
-		} else {
-			if e.child == nil {
-				e.child = &node{}
-			}
-			e.child.addRevision(remainingKey[len(e.prefix):], revision)
+func (n *node) dump(path []byte) {
+	for i := range n.entries {
+		e := &n.entries[i]
+		key := append(path, e.prefix...)
+		if e.revisions != nil {
+			fmt.Printf("key: %s, revisions: %v\n", key, e.revisions)
 		}
+		if e.child != nil {
+			e.child.dump(key)
+		}
+	}
+}
+
+// Len returns the number of keys in the index.
+func (t *BPTree) Len() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.keys
+}
+
+// find returns the index of the entry whose prefix starts with b, or the
+// index at which such an entry would be inserted, and whether it exists.
+func (n *node) find(b byte) (int, bool) {
+	i := sort.Search(len(n.entries), func(i int) bool { return n.entries[i].prefix[0] >= b })
+	return i, i < len(n.entries) && n.entries[i].prefix[0] == b
+}
+
+func commonPrefixLen(a, b []byte) int {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// AddRevision records that key was written at revision. Revisions for a key
+// are expected to be added in increasing order.
+func (t *BPTree) AddRevision(key []byte, revision Revision) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(key) == 0 {
+		if t.emptyKey == nil {
+			t.keys++
+		}
+		t.emptyKey = append(t.emptyKey, revision)
 		return
 	}
-
-	// We need to insert a new entry
-
-	// TODO: Split if we feel there are "too many" entries
-
-	newEntries := make([]nodeEntry, len(n.entries)+1)
-	copy(newEntries, n.entries[:pos])
-	newEntries[pos] = nodeEntry{prefix: remainingKey, revisions: []Revision{revision}}
-	copy(newEntries[pos+1:], n.entries[pos:])
-	n.entries = newEntries
+	if t.root.addRevision(key, revision) {
+		t.keys++
+	}
 }
 
-func (n *node) getLatestRevisionByKey(remainingKey []byte, atRevision Revision) (Revision, bool) {
-	n.mutex.RLock()
-	defer n.mutex.RUnlock()
-
-	pos, match := n.findEntry(remainingKey)
-	if !match {
-		return 0, false
+// addRevision adds revision for the key that continues with key from this
+// node. It returns true if the key is new.
+func (n *node) addRevision(key []byte, revision Revision) bool {
+	pos, found := n.find(key[0])
+	if !found {
+		// No entry shares a first byte with the key: a new leaf edge. Clone
+		// the key; callers pass buffers owned by request messages.
+		n.entries = slices.Insert(n.entries, pos, nodeEntry{prefix: bytes.Clone(key), revisions: []Revision{revision}})
+		return true
 	}
 
 	e := &n.entries[pos]
-
-	revisions := e.revisions
-	if len(revisions) > 0 && bytes.Equal(e.prefix, remainingKey) {
-		latest := Revision(0)
-		found := false
-		for _, r := range revisions {
-			if r <= atRevision {
-				if r > latest {
-					latest = r
-				}
-				found = true
-			}
+	common := commonPrefixLen(e.prefix, key)
+	if common == len(e.prefix) {
+		if common == len(key) {
+			// The key ends exactly at this entry.
+			isNew := e.revisions == nil
+			e.revisions = append(e.revisions, revision)
+			return isNew
 		}
-		return latest, found
+		// The entry's prefix is a prefix of the key: continue below it.
+		if e.child == nil {
+			e.child = &node{}
+		}
+		return e.child.addRevision(key[common:], revision)
 	}
 
-	if e.child != nil {
-		return e.child.getLatestRevisionByKey(remainingKey, atRevision)
+	// The key diverges inside the entry's prefix: split the entry at the
+	// common prefix. The old entry's remainder becomes the sole child of the
+	// new intermediate entry, keeping its revisions and subtree.
+	child := &node{entries: []nodeEntry{{
+		prefix:    e.prefix[common:],
+		revisions: e.revisions,
+		child:     e.child,
+	}}}
+	e.prefix = e.prefix[:common:common]
+	e.revisions = nil
+	e.child = child
+	if common == len(key) {
+		// The key ends exactly at the split point.
+		e.revisions = []Revision{revision}
+		return true
 	}
+	// The key's remainder differs from the old remainder in its first byte,
+	// so it becomes a second edge of the new child.
+	return child.addRevision(key[common:], revision)
+}
 
+// GetLatestRevisionByKey returns the latest revision at which key was
+// written that is <= atRevision, and whether there is one.
+func (t *BPTree) GetLatestRevisionByKey(key []byte, atRevision Revision) (Revision, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var revisions []Revision
+	if len(key) == 0 {
+		revisions = t.emptyKey
+	} else {
+		revisions = t.root.lookup(key)
+	}
+	// Revisions are ascending, so scan back from the newest.
+	for i := len(revisions) - 1; i >= 0; i-- {
+		if revisions[i] <= atRevision {
+			return revisions[i], true
+		}
+	}
 	return 0, false
 }
 
-// findEntry finds the index for the matching entry, or the insertion point if not found.
-func (n *node) findEntry(prefixRemaining []byte) (int, bool) {
-	i := 0
-
-	for ; i < len(n.entries); i++ {
-		e := &n.entries[i]
-
-		if e.child != nil {
-			if bytes.HasPrefix(prefixRemaining, e.prefix) {
-				return i, true
-			}
+// lookup returns the revisions of the key that continues with key from this
+// node, or nil.
+func (n *node) lookup(key []byte) []Revision {
+	for {
+		pos, found := n.find(key[0])
+		if !found {
+			return nil
 		}
-
-		cmp := bytes.Compare(e.prefix, prefixRemaining)
-		if cmp > 0 {
-			return i, false
+		e := &n.entries[pos]
+		if !bytes.HasPrefix(key, e.prefix) {
+			return nil
 		}
-
-		if cmp == 0 {
-			return i, true
+		if len(key) == len(e.prefix) {
+			return e.revisions
 		}
+		if e.child == nil {
+			return nil
+		}
+		key = key[len(e.prefix):]
+		n = e.child
 	}
-
-	return i, false
 }
 
-func (n *node) listRevisionsByKeyRange(fromPrefixRemaining []byte, atRevision Revision, callback func(key []byte, revisions []Revision) bool) bool {
-	n.mutex.RLock()
-	defer n.mutex.RUnlock()
+// ListRevisionsByKeyRange calls callback for every key >= startKey, in key
+// order, with all revisions at which the key was written (the caller filters
+// by revision), until callback returns false. The key passed to the callback
+// is only valid for the duration of the call. atRevision is accepted for
+// interface compatibility; callers filter revisions themselves.
+func (t *BPTree) ListRevisionsByKeyRange(startKey []byte, atRevision Revision, callback func(key []byte, revisions []Revision) bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if len(startKey) == 0 && t.emptyKey != nil {
+		if !callback(nil, t.emptyKey) {
+			return
+		}
+	}
+	path := make([]byte, 0, 256)
+	t.root.list(path, startKey, callback)
+}
 
-	// pos, match := n.findSupremumHoldingLock(fromPrefixRemaining)
-	// i := pos
-	// if !match && i > 0 {
-	// 	i--
-	// }
-
-	isMatch := false
+// list visits the keys below this node that are >= start (relative to this
+// node; nil once the start has been passed and everything qualifies), in
+// order. path is the key prefix leading to this node.
+func (n *node) list(path []byte, start []byte, callback func(key []byte, revisions []Revision) bool) bool {
+	// Skip entries that sort entirely before start: with distinct first
+	// bytes, that is every entry whose first byte is below start's.
 	i := 0
+	if len(start) > 0 {
+		i, _ = n.find(start[0])
+	}
 	for ; i < len(n.entries); i++ {
 		e := &n.entries[i]
-
-		minLen := min(len(e.prefix), len(fromPrefixRemaining))
-
-		cmp := bytes.Compare(e.prefix[:minLen], fromPrefixRemaining[:minLen])
-		if cmp > 0 {
-			break
-		}
-
-		if cmp == 0 {
-			isMatch = true
-			break
-		}
-	}
-
-	if isMatch {
-		e := &n.entries[i]
-		if len(e.revisions) > 0 && bytes.Compare(e.prefix, fromPrefixRemaining) >= 0 {
-			if !callback(e.prefix, e.revisions) {
-				return false
+		childStart := []byte(nil)
+		emitOwn := true
+		if len(start) > 0 {
+			m := min(len(e.prefix), len(start))
+			switch c := bytes.Compare(e.prefix[:m], start[:m]); {
+			case c < 0:
+				// The whole subtree is below start.
+				continue
+			case c == 0 && len(e.prefix) < len(start):
+				// start continues below this entry: the entry's own key
+				// is below start, and only part of its subtree qualifies.
+				emitOwn = false
+				childStart = start[len(e.prefix):]
+			default:
+				// e.prefix >= start: everything from here on qualifies.
 			}
+			// Later siblings are entirely above start.
+			start = nil
 		}
-
-		if e.child != nil {
-			if !e.child.listRevisionsByKeyRange(fromPrefixRemaining[len(e.prefix):], atRevision, callback) {
-				return false
-			}
-		}
-		i++
-	}
-
-	for ; i < len(n.entries); i++ {
-		e := &n.entries[i]
-		if len(e.revisions) > 0 {
-			if !callback(e.prefix, e.revisions) {
+		key := append(path, e.prefix...)
+		if emitOwn && e.revisions != nil {
+			if !callback(key, e.revisions) {
 				return false
 			}
 		}
 		if e.child != nil {
-			if bytes.HasPrefix(fromPrefixRemaining, e.prefix) {
-				if !e.child.listRevisionsByKeyRange(fromPrefixRemaining[len(e.prefix):], atRevision, callback) {
-					return false
-				}
+			if !e.child.list(key, childStart, callback) {
+				return false
 			}
 		}
 	}

--- a/pkg/bptree/radix_test.go
+++ b/pkg/bptree/radix_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bptree
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// reference is a sorted map used to check the tree.
+type reference struct {
+	revs map[string][]Revision
+}
+
+func (r *reference) add(key string, rev Revision) {
+	if r.revs == nil {
+		r.revs = map[string][]Revision{}
+	}
+	r.revs[key] = append(r.revs[key], rev)
+}
+
+func (r *reference) keysFrom(start string) []string {
+	var keys []string
+	for k := range r.revs {
+		if k >= start {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// checkAgainst verifies every lookup and every range scan the reference can
+// answer.
+func checkAgainst(t *testing.T, tree *BPTree, ref *reference, starts []string) {
+	t.Helper()
+	if tree.Len() != len(ref.revs) {
+		t.Fatalf("Len = %d, want %d", tree.Len(), len(ref.revs))
+	}
+	for k, revs := range ref.revs {
+		latest := revs[len(revs)-1]
+		if got, ok := tree.GetLatestRevisionByKey([]byte(k), latest); !ok || got != latest {
+			t.Fatalf("latest(%q) = %d,%v want %d", k, got, ok, latest)
+		}
+		if got, ok := tree.GetLatestRevisionByKey([]byte(k), revs[0]); !ok || got != revs[0] {
+			t.Fatalf("latest(%q at %d) = %d,%v want %d", k, revs[0], got, ok, revs[0])
+		}
+		if _, ok := tree.GetLatestRevisionByKey([]byte(k), revs[0]-1); ok {
+			t.Fatalf("latest(%q at %d) found something", k, revs[0]-1)
+		}
+	}
+	for _, start := range starts {
+		var got []string
+		tree.ListRevisionsByKeyRange([]byte(start), 1<<62, func(key []byte, revisions []Revision) bool {
+			got = append(got, string(key))
+			if want := ref.revs[string(key)]; fmt.Sprint(want) != fmt.Sprint(revisions) {
+				t.Fatalf("scan from %q: key %q revisions %v want %v", start, key, revisions, want)
+			}
+			return true
+		})
+		if want := ref.keysFrom(start); fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("scan from %q:\n got %q\nwant %q", start, got, want)
+		}
+	}
+}
+
+// TestRadixSplitting inserts keys that share prefixes in every combination
+// that forces a split, in several orders, and checks lookups and scans.
+func TestRadixSplitting(t *testing.T) {
+	keys := []string{"a", "ab", "abc", "abd", "abcd", "b", "ba", "", "/registry/pods/ns/p1", "/registry/pods/ns/p2", "/registry/pod", "/registry/pods", "/registry"}
+	orders := [][]string{keys, reverse(keys), shuffled(keys, 7), shuffled(keys, 11)}
+	starts := append([]string{"", "a", "aa", "ab", "abb", "abc", "abcc", "abd", "abz", "b", "bb", "/", "/registry/", "/registry/pods/", "/registry/pods/ns/p1", "/registry/pods/ns/p15", "z"}, keys...)
+	for _, order := range orders {
+		var tree BPTree
+		var ref reference
+		for i, k := range order {
+			tree.AddRevision([]byte(k), Revision(i+1))
+			ref.add(k, Revision(i+1))
+		}
+		// Second revisions, in a different order.
+		for i, k := range reverse(order) {
+			tree.AddRevision([]byte(k), Revision(100+i))
+			ref.add(k, Revision(100+i))
+		}
+		checkAgainst(t, &tree, &ref, starts)
+	}
+}
+
+// TestRadixRandom is a property test against the reference with random keys
+// drawn from a small alphabet, so that prefixes collide constantly.
+func TestRadixRandom(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	var tree BPTree
+	var ref reference
+	var starts []string
+	for i := 0; i < 5000; i++ {
+		n := rng.Intn(6)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = "abc/"[rng.Intn(4)]
+		}
+		k := string(b)
+		tree.AddRevision([]byte(k), Revision(i+1))
+		ref.add(k, Revision(i+1))
+		if i%100 == 0 {
+			starts = append(starts, k, k+"a", k[:len(k)/2])
+		}
+	}
+	checkAgainst(t, &tree, &ref, starts)
+}
+
+// TestKeysAreNotAliased checks that the tree does not retain the caller's
+// key buffer.
+func TestKeysAreNotAliased(t *testing.T) {
+	var tree BPTree
+	buf := []byte("/registry/minions/node-1")
+	tree.AddRevision(buf, 1)
+	copy(buf, "/registry/minions/node-2")
+	if _, ok := tree.GetLatestRevisionByKey([]byte("/registry/minions/node-1"), 1); !ok {
+		t.Fatal("key changed after the caller reused its buffer")
+	}
+	var got []string
+	tree.ListRevisionsByKeyRange(nil, 1, func(key []byte, _ []Revision) bool {
+		got = append(got, string(key))
+		return true
+	})
+	if len(got) != 1 || got[0] != "/registry/minions/node-1" {
+		t.Fatalf("scan = %q", got)
+	}
+}
+
+// TestBPTree_ManyKeys inserts keys in random order and checks ordering,
+// lookups, range scans and revision history at a size where a linear
+// structure would be visibly slow.
+func TestBPTree_ManyKeys(t *testing.T) {
+	const n = 200_000
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("/registry/pods/ns-%03d/pod-%06d", i%100, i))
+	}
+	perm := rand.New(rand.NewSource(1)).Perm(n)
+
+	var tree BPTree
+	for rev, i := range perm {
+		tree.AddRevision(keys[i], Revision(rev+1))
+	}
+	for rev, i := range perm {
+		tree.AddRevision(keys[i], Revision(n+rev+1))
+	}
+	if tree.Len() != n {
+		t.Fatalf("Len = %d, want %d", tree.Len(), n)
+	}
+	for rev, i := range perm {
+		if got, ok := tree.GetLatestRevisionByKey(keys[i], Revision(2*n)); !ok || got != Revision(n+rev+1) {
+			t.Fatalf("latest of %s = %d,%v; want %d", keys[i], got, ok, n+rev+1)
+		}
+		if got, ok := tree.GetLatestRevisionByKey(keys[i], Revision(n)); !ok || got != Revision(rev+1) {
+			t.Fatalf("latest of %s at %d = %d,%v; want %d", keys[i], n, got, ok, rev+1)
+		}
+	}
+	prefix := []byte("/registry/pods/ns-042/")
+	var seen [][]byte
+	tree.ListRevisionsByKeyRange(prefix, Revision(2*n), func(key []byte, revisions []Revision) bool {
+		if !bytes.HasPrefix(key, prefix) {
+			return false
+		}
+		if len(revisions) != 2 || revisions[0] >= revisions[1] {
+			t.Errorf("%s: revisions %v", key, revisions)
+		}
+		seen = append(seen, bytes.Clone(key))
+		return true
+	})
+	if len(seen) != n/100 {
+		t.Fatalf("range scan saw %d keys, want %d", len(seen), n/100)
+	}
+	for i := 1; i < len(seen); i++ {
+		if bytes.Compare(seen[i-1], seen[i]) >= 0 {
+			t.Fatalf("range scan out of order: %s before %s", seen[i-1], seen[i])
+		}
+	}
+}
+
+func BenchmarkAddRevision(b *testing.B) {
+	var tree BPTree
+	for i := 0; i < b.N; i++ {
+		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1))
+	}
+}
+
+func BenchmarkGetLatestRevisionByKey(b *testing.B) {
+	var tree BPTree
+	const n = 200_000
+	for i := 0; i < n; i++ {
+		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1))
+	}
+	keys := make([][]byte, 1024)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("/registry/minions/node-%08d", (i*7919)%n))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.GetLatestRevisionByKey(keys[i%len(keys)], Revision(n))
+	}
+}
+
+func reverse(s []string) []string {
+	out := make([]string, len(s))
+	for i, v := range s {
+		out[len(s)-1-i] = v
+	}
+	return out
+}
+
+func shuffled(s []string, seed int64) []string {
+	out := append([]string(nil), s...)
+	rand.New(rand.NewSource(seed)).Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+	return out
+}


### PR DESCRIPTION
## Summary

Alternative to #46 that **keeps the radix-tree design** (prefixes in memory, which leaves the door open to values on disk) and no external dependency — pick one.

`pkg/bptree` was written as a radix tree, but the branch that creates child nodes is unreachable and entries never split, so in practice it was one flat sorted slice: O(n) linear scan per lookup and a fresh copy of the whole slice per insert (~11 MB at 200k keys). That's the 27% `findEntry` / 45% GC in the 20k-node populate profile, and the ~1,000 ops/s ceiling the 100k-node run hit.

Now:
- an insert whose key diverges inside an entry's prefix **splits the entry at the common prefix**, so sibling entries never share a first byte — a node has at most 256 entries and is searched by binary search on that byte;
- inserts are in place (`slices.Insert`), not a slice copy;
- range scans **reconstruct full keys** along the path (the flat tree could hand out `e.prefix` as the key; a real tree can't) — the key passed to the callback is valid only during the call, which is how `memorystorage` uses it;
- the empty key gets its own slot (no first byte to place it by); keys are cloned on insert.

API unchanged (`AddRevision`, `GetLatestRevisionByKey`, `ListRevisionsByKeyRange`, usable zero value).

At 200k keys: **insert 311 ns, lookup 215 ns** (the btree in #46: 547 ns insert).

## 100k nodes (with #44 + #45, `cloud-etcd-bench`, nodes only, in-memory, 512 workers)

| | old index | this PR |
|---|---|---|
| populate 200k keys | 8 m 30 s (392/s) | **11.5 s (17,341/s)** |
| steady: node lease updates (need 10,000/s) | 888/s, lag 57 s ↑ | **9,979/s, lag < 1 ms** |
| write latency p50 / p99 | 387 ms / 1.0 s | **7.1 ms / 12.5 ms** |

## Test plan

- [x] Existing `bptree` tests unchanged
- [x] `TestRadixSplitting`: keys chosen to force every split case (`a`/`ab`/`abc`/`abd`/`abcd`, `/registry/pod` vs `/registry/pods`, empty key), inserted in four orders, checked against a sorted reference for lookups at two revisions and range scans from 30 start keys
- [x] `TestRadixRandom`: 5,000 random keys over a 4-byte alphabet (constant prefix collisions) against the reference
- [x] `TestKeysAreNotAliased`, `TestBPTree_ManyKeys` (200k keys)
- [x] `go test -race` bptree + storage; `go test ./...` 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek

