### PR TITLE
bench: add -pprof-addr to serve net/http/pprof during a run

### DIFF
--- a/cmd/cloud-etcd-bench/main.go
+++ b/cmd/cloud-etcd-bench/main.go
@@ -29,6 +29,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -100,6 +102,7 @@ func runBench(ctx context.Context, args []string) error {
 	stormRounds := fs.Int("list-storm-rounds", 1, "Full lists per lister in the list-storm phase")
 	cpuProfile := fs.String("cpuprofile", "", "Write a CPU profile to this file")
 	memProfile := fs.String("memprofile", "", "Write a heap profile to this file at the end")
+	pprofAddr := fs.String("pprof-addr", "", "Serve net/http/pprof on this address during the run (e.g. 127.0.0.1:6060)")
 	klog.InitFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -114,6 +117,14 @@ func runBench(ctx context.Context, args []string) error {
 	}
 	if err := cfg.Validate(); err != nil {
 		return err
+	}
+
+	if *pprofAddr != "" {
+		go func() {
+			if err := http.ListenAndServe(*pprofAddr, nil); err != nil {
+				fmt.Fprintf(os.Stderr, "pprof server: %v\n", err)
+			}
+		}()
 	}
 
 	if *cpuProfile != "" {


### PR DESCRIPTION
## Summary

`cloud-etcd-bench run -pprof-addr 127.0.0.1:6060` serves `net/http/pprof` for the duration of a run, so you can take a goroutine dump, heap or CPU profile *mid-run* (`curl 'http://127.0.0.1:6060/debug/pprof/goroutine?debug=2'`). `-cpuprofile`/`-memprofile` remain for whole-run profiles.

This is how the "watch delivers only ~1k of 10k events/s at 100k nodes" question got answered: a dump 20 s into steady state showed the server watchers in `stateCond.Wait`, the clientv3 substreams idle in `select`, and the consumers in `chan receive` — nothing was blocked; the earlier shortfalls were CPU contention from other benchmarks running on the same box. Run alone, the leases watch delivers 9,458/s.

## Test plan

- [x] `go build`, `go vet`
- [x] Used for the dump above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
