### PR TITLE
persistence: encode log batches as protobuf instead of JSON

### DIFF
--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -16,7 +16,6 @@ package filesystemlog
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 
 	"justinsb.com/cloudetcd/pkg/persistence"
 	"justinsb.com/cloudetcd/pkg/persistence/batch"
+	"justinsb.com/cloudetcd/pkg/persistence/logcodec"
 	"k8s.io/klog/v2"
 )
 
@@ -191,17 +191,13 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 	filename := batchToFilename(startRevision, count)
 	filepath := filepath.Join(l.dir, filename)
 
-	// Serialize record to JSON
-	// TODO: Use proto for speed
-	data := &persistedBatch{
-		Records: make([]*persistence.LogRecord, len(bc.Transactions)),
-	}
+	records := make([]*persistence.LogRecord, len(bc.Transactions))
 	for i, txn := range bc.Transactions {
-		data.Records[i] = txn.LogRecord
+		records[i] = txn.LogRecord
 	}
-	b, err := json.Marshal(data)
+	b, err := logcodec.Encode(records)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal log records: %w", err)
+		return nil, fmt.Errorf("failed to encode log records: %w", err)
 	}
 
 	// Write and fsync: this is the commit point, so the record must be
@@ -267,8 +263,8 @@ func (f *FilesystemLog) getLogEntry(revision Revision) (*LogRecord, error) {
 	}
 
 	record := &persistedBatch{}
-	if err := json.Unmarshal(data, record); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal log record from file %s: %w", filepath, err)
+	if record.Records, err = logcodec.Decode(data); err != nil {
+		return nil, fmt.Errorf("failed to decode log records from file %s: %w", filepath, err)
 	}
 
 	pos := int(revision - fileMeta.firstRevision)
@@ -320,8 +316,8 @@ func (f *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 		}
 
 		pBatch := &persistedBatch{}
-		if err := json.Unmarshal(data, pBatch); err != nil {
-			return fmt.Errorf("failed to unmarshal log record from file %s: %w", filepath, err)
+		if pBatch.Records, err = logcodec.Decode(data); err != nil {
+			return fmt.Errorf("failed to decode log records from file %s: %w", filepath, err)
 		}
 
 		for i, record := range pBatch.Records {

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -262,20 +262,16 @@ func (f *FilesystemLog) getLogEntry(revision Revision) (*LogRecord, error) {
 		return nil, fmt.Errorf("failed to read log file %q: %w", filepath, err)
 	}
 
-	record := &persistedBatch{}
-	if record.Records, err = logcodec.Decode(data); err != nil {
-		return nil, fmt.Errorf("failed to decode log records from file %s: %w", filepath, err)
-	}
-
+	// Decode just the record we want; the rest of the batch is skipped over.
 	pos := int(revision - fileMeta.firstRevision)
-	if pos < 0 || pos >= len(record.Records) {
-		return nil, fmt.Errorf("log entry not found in batch for revision %d (pos %d, count %d)", revision, pos, len(record.Records))
+	if pos < 0 || pos >= fileMeta.count {
+		return nil, fmt.Errorf("log entry not found in batch for revision %d (pos %d, count %d)", revision, pos, fileMeta.count)
 	}
-	if len(record.Records) != fileMeta.count {
-		// This would be a corruption error
-		klog.Warningf("log file %s has mismatched record count, file meta says %d, found %d", filepath, fileMeta.count, len(record.Records))
+	record, err := logcodec.DecodeRecord(data, pos)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, filepath, err)
 	}
-	return record.Records[pos], nil
+	return record, nil
 }
 
 // findFileForRevision finds the log file containing the given revision.

--- a/pkg/persistence/gcslog/gcs_log.go
+++ b/pkg/persistence/gcslog/gcs_log.go
@@ -16,7 +16,6 @@ package gcslog
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -41,6 +40,7 @@ import (
 	"google.golang.org/grpc/status"
 	"justinsb.com/cloudetcd/pkg/persistence"
 	"justinsb.com/cloudetcd/pkg/persistence/batch"
+	"justinsb.com/cloudetcd/pkg/persistence/logcodec"
 	"k8s.io/klog/v2"
 )
 
@@ -304,23 +304,21 @@ func (l *GCSLog) commitBatch(ctx context.Context, lastLogPosition Revision, bc *
 	objectName := l.batchToObjectName(startRevision, count)
 	obj := l.bucket.Object(objectName).If(storage.Conditions{DoesNotExist: true})
 
-	// Serialize record to JSON
-	// TODO: Use proto for speed
 	data := &persistedBatch{
 		Records: make([]*persistence.LogRecord, len(bc.Transactions)),
 	}
 	for i, txn := range bc.Transactions {
 		data.Records[i] = txn.LogRecord
 	}
-	b, err := json.Marshal(data)
+	b, err := logcodec.Encode(data.Records)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal log record: %w", err)
+		return nil, fmt.Errorf("failed to encode log records: %w", err)
 	}
 
 	// Write to GCS
 	log.Info("Writing log entry to GCS object", "objectName", objectName)
 	writer := obj.NewWriter(ctx)
-	writer.ContentType = "application/json"
+	writer.ContentType = "application/octet-stream"
 
 	if _, err := writer.Write(b); err != nil {
 		writer.Close()
@@ -396,8 +394,8 @@ func (g *GCSLog) loadBatch(ctx context.Context, fileMeta logFileMeta) (*persiste
 	}
 
 	pBatch := &persistedBatch{}
-	if err := json.Unmarshal(data, pBatch); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal log record from GCS object %s: %w", objectName, err)
+	if pBatch.Records, err = logcodec.Decode(data); err != nil {
+		return nil, fmt.Errorf("failed to decode log records from GCS object %s: %w", objectName, err)
 	}
 	return pBatch, nil
 }

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -52,6 +52,32 @@ func Encode(records []*persistence.LogRecord) ([]byte, error) {
 	return out, nil
 }
 
+// DecodeRecord decodes only record i of a batch, skipping the others: each
+// record is length-prefixed, so a skip is a varint read and a jump, and the
+// cost is the size of one record rather than of the batch. This is what a
+// log's GetLogEntry wants; Decode is for replay.
+func DecodeRecord(data []byte, i int) (*persistence.LogRecord, error) {
+	if !bytes.HasPrefix(data, magic) {
+		return nil, fmt.Errorf("not a cloudetcd log batch (bad header)")
+	}
+	data = data[len(magic):]
+	for n := 0; len(data) > 0; n++ {
+		m, k := protowire.ConsumeBytes(data)
+		if k < 0 {
+			return nil, fmt.Errorf("decoding record %d: %w", n, protowire.ParseError(k))
+		}
+		if n == i {
+			wr := &etcdserverpb.WatchResponse{}
+			if err := proto.Unmarshal(m, wr); err != nil {
+				return nil, fmt.Errorf("decoding record %d: %w", n, err)
+			}
+			return &persistence.LogRecord{Events: wr.Events}, nil
+		}
+		data = data[k:]
+	}
+	return nil, fmt.Errorf("record %d not in batch", i)
+}
+
 // Decode parses a batch produced by Encode.
 func Decode(data []byte) ([]*persistence.LogRecord, error) {
 	if !bytes.HasPrefix(data, magic) {

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logcodec is the on-disk / in-object encoding of a batch of log
+// records, shared by the file and object-store logs.
+//
+// A batch is a fixed header followed by one length-delimited protobuf
+// message per record. Each record is an etcdserverpb.WatchResponse carrying
+// the record's events: the events are already mvccpb.Event protobufs, so
+// this needs no generated code of its own, values are stored as raw bytes
+// rather than base64, and decoding is several times faster than the JSON
+// encoding it replaces.
+package logcodec
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"justinsb.com/cloudetcd/pkg/persistence"
+)
+
+// magic identifies the format; the last byte is the version.
+var magic = []byte("cloudetcd-log\x00\x01")
+
+// Encode serializes records as one batch.
+func Encode(records []*persistence.LogRecord) ([]byte, error) {
+	out := make([]byte, 0, len(magic)+len(records)*512)
+	out = append(out, magic...)
+	opts := proto.MarshalOptions{}
+	for i, r := range records {
+		m, err := opts.MarshalAppend(nil, &etcdserverpb.WatchResponse{Events: r.Events})
+		if err != nil {
+			return nil, fmt.Errorf("encoding record %d: %w", i, err)
+		}
+		out = protowire.AppendBytes(out, m)
+	}
+	return out, nil
+}
+
+// Decode parses a batch produced by Encode.
+func Decode(data []byte) ([]*persistence.LogRecord, error) {
+	if !bytes.HasPrefix(data, magic) {
+		return nil, fmt.Errorf("not a cloudetcd log batch (bad header)")
+	}
+	data = data[len(magic):]
+	var records []*persistence.LogRecord
+	for len(data) > 0 {
+		m, n := protowire.ConsumeBytes(data)
+		if n < 0 {
+			return nil, fmt.Errorf("decoding record %d: %w", len(records), protowire.ParseError(n))
+		}
+		data = data[n:]
+		wr := &etcdserverpb.WatchResponse{}
+		if err := proto.Unmarshal(m, wr); err != nil {
+			return nil, fmt.Errorf("decoding record %d: %w", len(records), err)
+		}
+		records = append(records, &persistence.LogRecord{Events: wr.Events})
+	}
+	return records, nil
+}

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -77,6 +77,43 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDecodeRecord(t *testing.T) {
+	in := batch(50)
+	data, err := Encode(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		got, err := DecodeRecord(data, i)
+		if err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+		if len(got.Events) != len(in[i].Events) {
+			t.Fatalf("record %d: %d events, want %d", i, len(got.Events), len(in[i].Events))
+		}
+		for j := range in[i].Events {
+			if !proto.Equal(got.Events[j], in[i].Events[j]) {
+				t.Fatalf("record %d event %d differs", i, j)
+			}
+		}
+	}
+	if _, err := DecodeRecord(data, len(in)); err == nil {
+		t.Error("decoded a record past the end of the batch")
+	}
+	if _, err := DecodeRecord(data[:len(data)-5], len(in)-1); err == nil {
+		t.Error("decoded the last record of a truncated batch")
+	}
+}
+
+func BenchmarkDecodeRecord(b *testing.B) {
+	data, _ := Encode(batch(500))
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeRecord(data, 250); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkEncode(b *testing.B) {
 	records := batch(500)
 	for i := 0; i < b.N; i++ {

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logcodec
+
+import (
+	"fmt"
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	"google.golang.org/protobuf/proto"
+
+	"justinsb.com/cloudetcd/pkg/persistence"
+)
+
+func batch(n int) []*persistence.LogRecord {
+	val := make([]byte, 1024)
+	for i := range val {
+		val[i] = byte(i)
+	}
+	var records []*persistence.LogRecord
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("/registry/leases/kube-node-lease/node-%06d", i))
+		records = append(records, &persistence.LogRecord{Events: []*mvccpb.Event{
+			{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: key, Value: val, CreateRevision: 100, ModRevision: int64(1000 + i), Version: 5, Lease: 7},
+				PrevKv: &mvccpb.KeyValue{Key: key, Value: val[:10], CreateRevision: 100, ModRevision: int64(900 + i), Version: 4}},
+			{Type: mvccpb.DELETE, Kv: &mvccpb.KeyValue{Key: append(key, '!'), ModRevision: int64(1000 + i)}},
+		}})
+	}
+	// An empty record (the log's revision-1 placeholder) and one with no events.
+	records = append(records, &persistence.LogRecord{}, &persistence.LogRecord{Events: []*mvccpb.Event{}})
+	return records
+}
+
+func TestRoundTrip(t *testing.T) {
+	in := batch(50)
+	data, err := Encode(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Decode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("decoded %d records, want %d", len(out), len(in))
+	}
+	for i := range in {
+		if len(out[i].Events) != len(in[i].Events) {
+			t.Fatalf("record %d: %d events, want %d", i, len(out[i].Events), len(in[i].Events))
+		}
+		for j := range in[i].Events {
+			if !proto.Equal(out[i].Events[j], in[i].Events[j]) {
+				t.Fatalf("record %d event %d differs:\n got %v\nwant %v", i, j, out[i].Events[j], in[i].Events[j])
+			}
+		}
+	}
+	if _, err := Decode([]byte(`{"Records":[]}`)); err == nil {
+		t.Error("decoded a JSON batch as valid")
+	}
+	if _, err := Decode(data[:len(data)-5]); err == nil {
+		t.Error("decoded a truncated batch as valid")
+	}
+	if out, err := Decode(data[:len(magic)]); err != nil || len(out) != 0 {
+		t.Errorf("empty batch: %v, %v", out, err)
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	records := batch(500)
+	for i := 0; i < b.N; i++ {
+		if _, err := Encode(records); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	data, _ := Encode(batch(500))
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		if _, err := Decode(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves the `TODO: Use proto for speed` in both `commitBatch`es. Independent of the other open PRs (branched from `main`), though it touches the same functions #45 does, so whichever lands second gets a trivial rebase — I'll do it.

Batches were JSON: every value base64-encoded, field names repeated per record, and decoding a 500-record batch of 1 KB values cost ~5.8 ms — paid on every `GetLogEntry` in the file log (the Txn path's prev-value lookup, `applyUpTo`, each watcher) and on replay.

New `pkg/persistence/logcodec`: a batch is a header (`cloudetcd-log\0` + version byte) followed by one length-delimited protobuf per record — an `etcdserverpb.WatchResponse` carrying the record's `mvccpb.Event`s, so there's no generated code of our own and values are raw bytes. Used by `filesystemlog` and `gcslog` (content type `application/octet-stream`); `memorylog` never serialized. File/object names are unchanged (`<rev>-<count>.log`).

**No reader for the old JSON format** — per discussion, there's no data to keep. Existing log directories/buckets must be cleared.

For the 500-record / 1 KB-value batch:

| | JSON | proto |
|---|---|---|
| size | 1,519 KB | **1,086 KB (−29%)** |
| decode | 5.76 ms | **0.93 ms** |
| encode | 2.34 ms | **1.47 ms** |

## Point lookups decode one record (second commit)

Because records are length-prefixed, `logcodec.DecodeRecord(data, i)` skips to record *i* (a varint read and a jump per record) and decodes only that one. `filesystemlog.GetLogEntry` uses it, so a prev-value lookup on the Txn path costs the size of one record rather than the batch: **3.9 µs vs 946 µs** for record 250 of a 500-record batch.

On a build with #44 + #45 + #47, 10k nodes on `filesystem://`:

| | JSON (before) | proto, decode-all | proto, `DecodeRecord` |
|---|---|---|---|
| populate 20k keys | 552/s | 1,955/s | **5,035/s** |
| steady write p50 | 32.5 ms | 29.5 ms | 29.5 ms |

Steady latency doesn't move because it's the disk: a 100 KB write+fsync on this box is ~9 ms and there's one batch per 10 ms window, so batches queue on the device. That's "window + your fsync", not the codec.

## Test plan

- [x] `logcodec` round-trip (PUT with prev_kv, DELETE, lease, empty records), `DecodeRecord` for every index plus past-the-end and truncated input; benchmarks
- [x] `go test -race ./pkg/persistence/...` — file, GCS-emulator and tiered conformance suites on the new format
- [x] `go test ./...` 12/12, `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek

