### PR TITLE
persistence: keep values on disk, with a bounded in-memory working set

### DIFF
--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -27,6 +27,7 @@ import (
 	"justinsb.com/cloudetcd/pkg/persistence"
 	"justinsb.com/cloudetcd/pkg/persistence/batch"
 	"justinsb.com/cloudetcd/pkg/persistence/logcodec"
+	"justinsb.com/cloudetcd/pkg/persistence/recordcache"
 	"k8s.io/klog/v2"
 )
 
@@ -40,7 +41,22 @@ type logFileMeta struct {
 	count         int
 }
 
-// FilesystemLog is a filesystem-backed implementation of the Log interface
+// Options configures a FilesystemLog.
+type Options struct {
+	// CacheBytes bounds the in-memory cache of decoded records; records not
+	// in it are read from disk on demand. <= 0 means unbounded.
+	CacheBytes int64
+}
+
+// DefaultCacheBytes is the record cache budget when Options.CacheBytes is 0.
+const DefaultCacheBytes = 256 << 20
+
+// FilesystemLog is a filesystem-backed implementation of the Log interface.
+//
+// Values live on disk: the log keeps in memory only its file index, the byte
+// offset of each record within its file, and a bounded cache of recently
+// written or read records. Reading a record that is not cached is a single
+// positioned read of that record's bytes.
 type FilesystemLog struct {
 	batching *batch.Batching
 
@@ -51,21 +67,41 @@ type FilesystemLog struct {
 
 	// logFiles is an in-memory index of log files, sorted by firstRevision
 	logFiles []logFileMeta
+
+	// spans locates each record within its file, keyed by the file's first
+	// revision. Filled at commit time; rebuilt on first use for files that
+	// existed at startup. Guarded by spansMu.
+	spansMu sync.Mutex
+	spans   map[Revision][]logcodec.Span
+
+	// cache holds recently written and read records.
+	cache *recordcache.Cache
 }
 
 var _ persistence.Log = &FilesystemLog{}
 var _ persistence.BatchAppender = &FilesystemLog{}
 var _ persistence.Truncater = &FilesystemLog{}
 
-// NewFilesystemLog creates a new filesystem-backed log
+// NewFilesystemLog creates a new filesystem-backed log with default Options.
 func NewFilesystemLog(dir string) (*FilesystemLog, error) {
+	return NewFilesystemLogWithOptions(dir, Options{})
+}
+
+// NewFilesystemLogWithOptions creates a new filesystem-backed log.
+func NewFilesystemLogWithOptions(dir string, opts Options) (*FilesystemLog, error) {
 	// Ensure the directory exists
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create log directory: %w", err)
 	}
+	cacheBytes := opts.CacheBytes
+	if cacheBytes == 0 {
+		cacheBytes = DefaultCacheBytes
+	}
 
 	log := &FilesystemLog{
-		dir: dir,
+		dir:   dir,
+		spans: map[Revision][]logcodec.Span{},
+		cache: recordcache.New(cacheBytes),
 	}
 
 	// Replay existing log entries to determine current revision
@@ -163,6 +199,12 @@ func (f *FilesystemLog) Truncate(ctx context.Context, throughRevision Revision) 
 				f.logFiles = append(kept, f.logFiles[i:]...)
 				return fmt.Errorf("failed to remove log file %q: %w", filename, err)
 			}
+			f.spansMu.Lock()
+			delete(f.spans, fileMeta.firstRevision)
+			f.spansMu.Unlock()
+			for r := fileMeta.firstRevision; r <= fileLastRevision; r++ {
+				f.cache.Remove(r)
+			}
 		} else {
 			kept = append(kept, fileMeta)
 		}
@@ -206,7 +248,11 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 		return nil, fmt.Errorf("failed to write log file: %w", err)
 	}
 
-	return &fileCommit{log: l, path: filepath, lastLogPosition: lastLogPosition, count: count}, nil
+	spans, err := logcodec.Offsets(b)
+	if err != nil {
+		return nil, fmt.Errorf("indexing log file %s: %w", filepath, err)
+	}
+	return &fileCommit{log: l, path: filepath, lastLogPosition: lastLogPosition, records: records, spans: spans}, nil
 }
 
 // fileCommit is a written, unpublished log file.
@@ -214,7 +260,8 @@ type fileCommit struct {
 	log             *FilesystemLog
 	path            string
 	lastLogPosition Revision
-	count           int
+	records         []*persistence.LogRecord
+	spans           []logcodec.Span
 }
 
 func (c *fileCommit) Publish() {
@@ -226,13 +273,22 @@ func (c *fileCommit) Publish() {
 		panic(fmt.Sprintf("batch published out of order: expected to publish after %d, log is at %d", c.lastLogPosition, l.lastRevision))
 	}
 	startRevision := l.lastRevision + 1
-	l.logFiles = append(l.logFiles, logFileMeta{firstRevision: startRevision, count: c.count})
-	l.lastRevision += Revision(c.count)
+	count := len(c.records)
+	l.spansMu.Lock()
+	l.spans[startRevision] = c.spans
+	l.spansMu.Unlock()
+	// Just-published records are the hottest: the transactions that wrote
+	// them, the index apply and the watchers all read them next.
+	for i, r := range c.records {
+		l.cache.Put(startRevision+Revision(i), r)
+	}
+	l.logFiles = append(l.logFiles, logFileMeta{firstRevision: startRevision, count: count})
+	l.lastRevision += Revision(count)
 	if l.listener != nil {
 		l.listener.OnLogEntry(l.lastRevision)
 	}
 	klog.V(2).Infof("Executed batch of %d transactions, revisions %d-%d",
-		c.count, startRevision, l.lastRevision)
+		count, startRevision, l.lastRevision)
 }
 
 // GetCurrentRevision returns the current revision number
@@ -250,28 +306,69 @@ func (f *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 }
 
 func (f *FilesystemLog) getLogEntry(revision Revision) (*LogRecord, error) {
+	if record, ok := f.cache.Get(revision); ok {
+		return record, nil
+	}
+
 	fileMeta, ok := f.findFileForRevision(revision)
 	if !ok {
 		return nil, fmt.Errorf("log entry for revision %d not found in any file", revision)
 	}
-
-	filename := batchToFilename(fileMeta.firstRevision, fileMeta.count)
-	filepath := filepath.Join(f.dir, filename)
-	data, err := os.ReadFile(filepath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read log file %q: %w", filepath, err)
-	}
-
-	// Decode just the record we want; the rest of the batch is skipped over.
 	pos := int(revision - fileMeta.firstRevision)
 	if pos < 0 || pos >= fileMeta.count {
 		return nil, fmt.Errorf("log entry not found in batch for revision %d (pos %d, count %d)", revision, pos, fileMeta.count)
 	}
-	record, err := logcodec.DecodeRecord(data, pos)
+
+	filename := batchToFilename(fileMeta.firstRevision, fileMeta.count)
+	filepath := filepath.Join(f.dir, filename)
+	spans, err := f.fileSpans(fileMeta, filepath)
+	if err != nil {
+		return nil, err
+	}
+	if pos >= len(spans) {
+		return nil, fmt.Errorf("log file %s has %d records, expected %d", filepath, len(spans), fileMeta.count)
+	}
+
+	// One positioned read of exactly this record's bytes.
+	span := spans[pos]
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %q: %w", filepath, err)
+	}
+	defer file.Close()
+	buf := make([]byte, span.Length)
+	if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
+		return nil, fmt.Errorf("failed to read record %d from log file %q: %w", revision, filepath, err)
+	}
+	record, err := logcodec.DecodeMessage(buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, filepath, err)
 	}
+	f.cache.Put(revision, record)
 	return record, nil
+}
+
+// fileSpans returns the record spans of a log file, scanning the file's
+// length prefixes on first use for files that predate this process.
+func (f *FilesystemLog) fileSpans(fileMeta logFileMeta, filepath string) ([]logcodec.Span, error) {
+	f.spansMu.Lock()
+	spans, ok := f.spans[fileMeta.firstRevision]
+	f.spansMu.Unlock()
+	if ok {
+		return spans, nil
+	}
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read log file %q: %w", filepath, err)
+	}
+	spans, err = logcodec.Offsets(data)
+	if err != nil {
+		return nil, fmt.Errorf("indexing log file %s: %w", filepath, err)
+	}
+	f.spansMu.Lock()
+	f.spans[fileMeta.firstRevision] = spans
+	f.spansMu.Unlock()
+	return spans, nil
 }
 
 // findFileForRevision finds the log file containing the given revision.

--- a/pkg/persistence/filesystemlog/filesystem_log_test.go
+++ b/pkg/persistence/filesystemlog/filesystem_log_test.go
@@ -15,6 +15,7 @@
 package filesystemlog
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -292,5 +293,55 @@ func TestFilesystemLog_ExampleUsage(t *testing.T) {
 	// Verify the new record
 	if records[4] == nil || records[4].Events[0].Type != mvccpb.PUT || string(records[4].Events[0].Kv.Key) != "user:3" || string(records[4].Events[0].Kv.Value) != "Charlie" {
 		t.Errorf("Fourth record mismatch: %+v", records[4])
+	}
+}
+
+// TestFilesystemLog_TinyCache runs the whole log suite with a record cache
+// too small to hold anything, so every GetLogEntry is a positioned read of
+// one record from disk.
+func TestFilesystemLog_TinyCache(t *testing.T) {
+	logtests.RunAll(t, func(t *testing.T) persistence.Log {
+		log, err := NewFilesystemLogWithOptions(t.TempDir(), Options{CacheBytes: 1})
+		if err != nil {
+			t.Fatalf("Failed to create filesystem log: %v", err)
+		}
+		return log
+	})
+}
+
+// TestFilesystemLog_ReadsAfterRestart checks that a log reopened on an
+// existing directory reads individual records from files it did not write
+// (rebuilding their record offsets on first use), with the cache disabled.
+func TestFilesystemLog_ReadsAfterRestart(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	log1, err := NewFilesystemLogWithOptions(dir, Options{CacheBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 40
+	for i := 0; i < n; i++ {
+		rec := &persistence.LogRecord{Events: []*mvccpb.Event{{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(fmt.Sprintf("k%03d", i)), Value: make([]byte, 100+i)}}}}
+		if _, ok, err := log1.Append(ctx, rec, persistence.NewTxnMeta(0)); err != nil || !ok {
+			t.Fatalf("append %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if err := log1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	log2, err := NewFilesystemLogWithOptions(dir, Options{CacheBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer log2.Close()
+	for r := persistence.Revision(1); r <= n; r++ {
+		rec, err := log2.GetLogEntry(r)
+		if err != nil {
+			t.Fatalf("GetLogEntry(%d): %v", r, err)
+		}
+		if want := fmt.Sprintf("k%03d", r-1); string(rec.Events[0].Kv.Key) != want || len(rec.Events[0].Kv.Value) != 100+int(r-1) {
+			t.Fatalf("GetLogEntry(%d) = %s (%d bytes), want %s (%d bytes)", r, rec.Events[0].Kv.Key, len(rec.Events[0].Kv.Value), want, 100+int(r-1))
+		}
 	}
 }

--- a/pkg/persistence/gcslog/cache.go
+++ b/pkg/persistence/gcslog/cache.go
@@ -16,105 +16,71 @@ package gcslog
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"justinsb.com/cloudetcd/pkg/persistence"
+	"justinsb.com/cloudetcd/pkg/persistence/recordcache"
 )
 
+// Cache is the log's in-memory working set: a byte-budgeted LRU of decoded
+// records (see recordcache), filled as batches are written and as they are
+// fetched from GCS. Concurrent fetches of the same batch are coalesced.
 type Cache struct {
-	mu    sync.Mutex
-	cache map[Revision]*cacheEntry
+	records *recordcache.Cache
+
+	mu      sync.Mutex
+	loading map[Revision]*sync.Mutex // per batch (by first revision)
 }
 
-type cacheEntry struct {
-	mu       sync.Mutex
-	revision Revision
-	record   *persistence.LogRecord
+// NewCache creates a cache holding at most budgetBytes of records (<= 0:
+// unbounded).
+func NewCache(budgetBytes int64) *Cache {
+	return &Cache{records: recordcache.New(budgetBytes), loading: map[Revision]*sync.Mutex{}}
 }
 
-func NewCache() *Cache {
-	c := &Cache{
-		cache: make(map[Revision]*cacheEntry),
-	}
-	return c
-}
-
+// Has reports whether revision is cached.
 func (c *Cache) Has(revision Revision) bool {
-	entry := c.getEntry(revision, false)
-	if entry == nil {
-		return false
-	}
-	return entry.hasValue()
-}
-
-// getEntry returns the cache entry for the given revision
-func (c *Cache) getEntry(revision Revision, create bool) *cacheEntry {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	entry, ok := c.cache[revision]
-	if !ok && create {
-		entry = &cacheEntry{
-			revision: revision,
-		}
-		c.cache[revision] = entry
-	}
-	return entry
+	return c.records.Has(revision)
 }
 
 type LoadBatchFunc func(ctx context.Context, meta logFileMeta) (*persistedBatch, error)
 
+// Get returns the record for revision, fetching and caching its whole batch
+// with load if it is not cached.
 func (c *Cache) Get(ctx context.Context, revision Revision, load LoadBatchFunc, meta logFileMeta) (*persistence.LogRecord, error) {
-	entry := c.getEntry(revision, true)
+	if record, ok := c.records.Get(revision); ok {
+		return record, nil
+	}
 
-	batch, record, err := entry.loadRecord(ctx, meta, load)
+	c.mu.Lock()
+	batchMu := c.loading[meta.firstRevision]
+	if batchMu == nil {
+		batchMu = &sync.Mutex{}
+		c.loading[meta.firstRevision] = batchMu
+	}
+	c.mu.Unlock()
+
+	batchMu.Lock()
+	defer batchMu.Unlock()
+	if record, ok := c.records.Get(revision); ok {
+		return record, nil
+	}
+	batch, err := load(ctx, meta)
 	if err != nil {
 		return nil, err
 	}
-	if batch != nil {
-		for i := 0; i < meta.count; i++ {
-			pos := meta.firstRevision + Revision(i)
-			logEntry := batch.Records[i]
-			entry := c.getEntry(pos, true)
-			entry.setRecord(logEntry)
-		}
+	pos := int(revision - meta.firstRevision)
+	if pos < 0 || pos >= len(batch.Records) {
+		return nil, fmt.Errorf("log entry not found in batch for revision %d (pos %d, count %d)", revision, pos, len(batch.Records))
 	}
-	return record, nil
+	c.notifyBatch(meta.firstRevision, batch)
+	return batch.Records[pos], nil
 }
 
+// notifyBatch caches every record of a batch.
 func (c *Cache) notifyBatch(firstRevision Revision, data *persistedBatch) {
 	for i, record := range data.Records {
-		pos := firstRevision + Revision(i)
-		entry := c.getEntry(pos, true)
-		entry.setRecord(record)
+		c.records.Put(firstRevision+Revision(i), record)
 	}
-}
-
-func (e *cacheEntry) setRecord(record *persistence.LogRecord) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.record = record
-}
-
-func (e *cacheEntry) loadRecord(ctx context.Context, meta logFileMeta, load LoadBatchFunc) (*persistedBatch, *persistence.LogRecord, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.record != nil {
-		return nil, e.record, nil
-	}
-
-	batch, err := load(ctx, meta)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logEntry := batch.Records[e.revision-meta.firstRevision]
-	e.record = logEntry
-	return batch, logEntry, nil
-}
-
-func (e *cacheEntry) hasValue() bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.record != nil
 }

--- a/pkg/persistence/gcslog/emulator_test.go
+++ b/pkg/persistence/gcslog/emulator_test.go
@@ -79,3 +79,20 @@ func TestGCSLogWithEmulator(t *testing.T) {
 
 	logtests.RunAll(t, logFactory)
 }
+
+// TestGCSLogWithEmulatorTinyCache runs the suite with a record cache too
+// small to hold anything, so every GetLogEntry re-fetches its batch.
+func TestGCSLogWithEmulatorTinyCache(t *testing.T) {
+	bucketName := "cloudetcd-test-tinycache"
+	startEmulator(t, bucketName)
+
+	ctx := t.Context()
+	logtests.RunAll(t, func(t *testing.T) persistence.Log {
+		prefix := fmt.Sprintf("test-log-%d/", time.Now().UnixNano())
+		log, err := NewGCSLogWithOptions(ctx, bucketName, prefix, Options{CacheBytes: 1})
+		if err != nil {
+			t.Fatalf("Failed to create GCS log: %v", err)
+		}
+		return log
+	})
+}

--- a/pkg/persistence/gcslog/gcs_log.go
+++ b/pkg/persistence/gcslog/gcs_log.go
@@ -169,7 +169,28 @@ func metricsClientOptions(ctx context.Context) ([]option.ClientOption, error) {
 }
 
 // NewGCSLog creates a new Google Cloud Storage-backed log
+// Options configures a GCSLog.
+type Options struct {
+	// CacheBytes bounds the in-memory cache of decoded records; records not
+	// in it are fetched from GCS (a whole batch at a time) on demand.
+	// <= 0 means unbounded.
+	CacheBytes int64
+}
+
+// DefaultCacheBytes is the record cache budget when Options.CacheBytes is 0.
+const DefaultCacheBytes = 256 << 20
+
+// NewGCSLog creates a new Google Cloud Storage-backed log with default Options.
 func NewGCSLog(ctx context.Context, bucketName, prefix string) (*GCSLog, error) {
+	return NewGCSLogWithOptions(ctx, bucketName, prefix, Options{})
+}
+
+// NewGCSLogWithOptions creates a new Google Cloud Storage-backed log.
+func NewGCSLogWithOptions(ctx context.Context, bucketName, prefix string, opts Options) (*GCSLog, error) {
+	cacheBytes := opts.CacheBytes
+	if cacheBytes == 0 {
+		cacheBytes = DefaultCacheBytes
+	}
 	client, err := newStorageClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %w", err)
@@ -187,7 +208,7 @@ func NewGCSLog(ctx context.Context, bucketName, prefix string) (*GCSLog, error) 
 		client: client,
 		bucket: bucket,
 		prefix: prefix,
-		cache:  NewCache(),
+		cache:  NewCache(cacheBytes),
 	}
 
 	// Replay existing log entries to determine current revision

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -78,6 +78,45 @@ func DecodeRecord(data []byte, i int) (*persistence.LogRecord, error) {
 	return nil, fmt.Errorf("record %d not in batch", i)
 }
 
+// Span locates one record's message bytes within an encoded batch.
+type Span struct {
+	Offset int
+	Length int
+}
+
+// Offsets returns the span of every record in a batch without decoding any
+// of them: it reads only the length prefixes. With the spans, a record can be
+// read from storage by itself (see DecodeMessage).
+func Offsets(data []byte) ([]Span, error) {
+	if !bytes.HasPrefix(data, magic) {
+		return nil, fmt.Errorf("not a cloudetcd log batch (bad header)")
+	}
+	pos := len(magic)
+	var spans []Span
+	for pos < len(data) {
+		n, k := protowire.ConsumeVarint(data[pos:])
+		if k < 0 {
+			return nil, fmt.Errorf("decoding record %d: %w", len(spans), protowire.ParseError(k))
+		}
+		if uint64(len(data)-pos-k) < n {
+			return nil, fmt.Errorf("decoding record %d: truncated", len(spans))
+		}
+		spans = append(spans, Span{Offset: pos + k, Length: int(n)})
+		pos += k + int(n)
+	}
+	return spans, nil
+}
+
+// DecodeMessage decodes one record from its message bytes (the Span returned
+// by Offsets).
+func DecodeMessage(m []byte) (*persistence.LogRecord, error) {
+	wr := &etcdserverpb.WatchResponse{}
+	if err := proto.Unmarshal(m, wr); err != nil {
+		return nil, err
+	}
+	return &persistence.LogRecord{Events: wr.Events}, nil
+}
+
 // Decode parses a batch produced by Encode.
 func Decode(data []byte) ([]*persistence.LogRecord, error) {
 	if !bytes.HasPrefix(data, magic) {

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -105,6 +105,38 @@ func TestDecodeRecord(t *testing.T) {
 	}
 }
 
+func TestOffsets(t *testing.T) {
+	in := batch(50)
+	data, err := Encode(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans, err := Offsets(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spans) != len(in) {
+		t.Fatalf("%d spans, want %d", len(spans), len(in))
+	}
+	for i, sp := range spans {
+		got, err := DecodeMessage(data[sp.Offset : sp.Offset+sp.Length])
+		if err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+		if len(got.Events) != len(in[i].Events) {
+			t.Fatalf("record %d: %d events, want %d", i, len(got.Events), len(in[i].Events))
+		}
+		for j := range in[i].Events {
+			if !proto.Equal(got.Events[j], in[i].Events[j]) {
+				t.Fatalf("record %d event %d differs", i, j)
+			}
+		}
+	}
+	if _, err := Offsets(data[:len(data)-5]); err == nil {
+		t.Error("offsets of a truncated batch succeeded")
+	}
+}
+
 func BenchmarkDecodeRecord(b *testing.B) {
 	data, _ := Encode(batch(500))
 	for i := 0; i < b.N; i++ {

--- a/pkg/persistence/logfactory/logfactory.go
+++ b/pkg/persistence/logfactory/logfactory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,12 +36,22 @@ func NewLog(ctx context.Context, uri string) (persistence.Log, error) {
 	}
 	switch u.Scheme {
 	case "filesystem":
+		// filesystem:///var/lib/cloudetcd/log?cache=256MB bounds the in-memory
+		// record cache; values are read from disk on demand.
 		dir := "/" + u.Host + "/" + u.Path
-		return filesystemlog.NewFilesystemLog(dir)
+		cacheBytes, err := parseSize(u.Query().Get("cache"))
+		if err != nil {
+			return nil, err
+		}
+		return filesystemlog.NewFilesystemLogWithOptions(dir, filesystemlog.Options{CacheBytes: cacheBytes})
 	case "gs":
 		// gs://bucket/some/prefix/ => bucket "bucket", object prefix "some/prefix/"
 		// (GCS object names do not start with a slash)
-		return gcslog.NewGCSLog(ctx, u.Host, strings.TrimPrefix(u.Path, "/"))
+		cacheBytes, err := parseSize(u.Query().Get("cache"))
+		if err != nil {
+			return nil, err
+		}
+		return gcslog.NewGCSLogWithOptions(ctx, u.Host, strings.TrimPrefix(u.Path, "/"), gcslog.Options{CacheBytes: cacheBytes})
 	case "memory":
 		// memory://?commitLatency=50ms emulates an object-store backend's
 		// commit round-trip on top of the in-memory log.
@@ -62,9 +73,10 @@ func NewLog(ctx context.Context, uri string) (persistence.Log, error) {
 
 // newTieredLog builds a tiered log from a URI of the form:
 //
-//	tiered:?fast=filesystem:///var/lib/cloudetcd/log&archive=gs://bucket/logs/&flushInterval=5m
+//	tiered:?fast=filesystem:///var/lib/cloudetcd/log&archive=gs://bucket/logs/&flushInterval=5m&retain=true
 //
 // The fast and archive parameters are themselves log URIs (URL-encoded).
+// retain=true keeps archived records in the fast tier so reads stay local.
 func newTieredLog(ctx context.Context, u *url.URL) (persistence.Log, error) {
 	query := u.Query()
 
@@ -75,6 +87,13 @@ func newTieredLog(ctx context.Context, u *url.URL) (persistence.Log, error) {
 	}
 
 	options := tieredlog.Options{}
+	if retain := query.Get("retain"); retain != "" {
+		b, err := strconv.ParseBool(retain)
+		if err != nil {
+			return nil, fmt.Errorf("parsing retain %q: %w", retain, err)
+		}
+		options.RetainFastTier = b
+	}
 	if flushInterval := query.Get("flushInterval"); flushInterval != "" {
 		d, err := time.ParseDuration(flushInterval)
 		if err != nil {
@@ -100,4 +119,36 @@ func newTieredLog(ctx context.Context, u *url.URL) (persistence.Log, error) {
 		return nil, err
 	}
 	return log, nil
+}
+
+// parseSize parses a byte size such as "256MB", "1GiB", "64k" or "1048576".
+// An empty string is 0.
+func parseSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	units := []struct {
+		suffix string
+		mult   int64
+	}{
+		{"GiB", 1 << 30}, {"GB", 1 << 30}, {"G", 1 << 30},
+		{"MiB", 1 << 20}, {"MB", 1 << 20}, {"M", 1 << 20},
+		{"KiB", 1 << 10}, {"KB", 1 << 10}, {"K", 1 << 10},
+		{"B", 1},
+	}
+	mult := int64(1)
+	num := s
+	for _, u := range units {
+		if strings.HasSuffix(strings.ToUpper(s), strings.ToUpper(u.suffix)) {
+			mult = u.mult
+			num = s[:len(s)-len(u.suffix)]
+			break
+		}
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(num), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing size %q: %w", s, err)
+	}
+	return n * mult, nil
 }

--- a/pkg/persistence/recordcache/recordcache.go
+++ b/pkg/persistence/recordcache/recordcache.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package recordcache is a byte-budgeted LRU cache of decoded log records,
+// keyed by revision. It is the in-memory working set of a log whose values
+// live on disk or in an object store: recently written and recently read
+// records stay in memory; everything else is re-read from the backend.
+package recordcache
+
+import (
+	"container/list"
+	"sync"
+
+	"justinsb.com/cloudetcd/pkg/persistence"
+)
+
+type Revision = persistence.Revision
+
+// Cache is safe for concurrent use.
+type Cache struct {
+	mu     sync.Mutex
+	budget int64
+	used   int64
+	ll     *list.List // front = most recently used
+	items  map[Revision]*list.Element
+}
+
+type item struct {
+	revision Revision
+	record   *persistence.LogRecord
+	size     int64
+}
+
+// New creates a cache that holds at most budgetBytes of records (as measured
+// by Size). A budget <= 0 means unbounded.
+func New(budgetBytes int64) *Cache {
+	return &Cache{budget: budgetBytes, ll: list.New(), items: map[Revision]*list.Element{}}
+}
+
+// Size estimates the memory a record occupies: its keys and values plus a
+// fixed overhead per event for the structs.
+func Size(record *persistence.LogRecord) int64 {
+	const eventOverhead = 160
+	var n int64 = 64
+	for _, e := range record.Events {
+		n += eventOverhead
+		if e.Kv != nil {
+			n += int64(len(e.Kv.Key) + len(e.Kv.Value))
+		}
+		if e.PrevKv != nil {
+			n += int64(len(e.PrevKv.Key) + len(e.PrevKv.Value))
+		}
+	}
+	return n
+}
+
+// Get returns the record for revision, marking it recently used.
+func (c *Cache) Get(revision Revision) (*persistence.LogRecord, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[revision]
+	if !ok {
+		return nil, false
+	}
+	c.ll.MoveToFront(el)
+	return el.Value.(*item).record, true
+}
+
+// Has reports whether revision is cached, without touching its recency.
+func (c *Cache) Has(revision Revision) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.items[revision]
+	return ok
+}
+
+// Put caches the record for revision, evicting least recently used records
+// to stay within budget. A record larger than the whole budget is not cached.
+func (c *Cache) Put(revision Revision, record *persistence.LogRecord) {
+	size := Size(record)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[revision]; ok {
+		it := el.Value.(*item)
+		c.used += size - it.size
+		it.record, it.size = record, size
+		c.ll.MoveToFront(el)
+	} else {
+		if c.budget > 0 && size > c.budget {
+			return
+		}
+		c.items[revision] = c.ll.PushFront(&item{revision: revision, record: record, size: size})
+		c.used += size
+	}
+	for c.budget > 0 && c.used > c.budget && c.ll.Len() > 1 {
+		c.evictOldest()
+	}
+}
+
+// Remove drops the record for revision, if cached.
+func (c *Cache) Remove(revision Revision) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[revision]; ok {
+		c.removeElement(el)
+	}
+}
+
+func (c *Cache) evictOldest() {
+	if el := c.ll.Back(); el != nil {
+		c.removeElement(el)
+	}
+}
+
+func (c *Cache) removeElement(el *list.Element) {
+	it := el.Value.(*item)
+	c.ll.Remove(el)
+	delete(c.items, it.revision)
+	c.used -= it.size
+}
+
+// Len returns the number of cached records.
+func (c *Cache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ll.Len()
+}
+
+// Bytes returns the estimated bytes of cached records.
+func (c *Cache) Bytes() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.used
+}

--- a/pkg/persistence/recordcache/recordcache_test.go
+++ b/pkg/persistence/recordcache/recordcache_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recordcache
+
+import (
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+
+	"justinsb.com/cloudetcd/pkg/persistence"
+)
+
+func rec(valueBytes int) *persistence.LogRecord {
+	return &persistence.LogRecord{Events: []*mvccpb.Event{{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte("k"), Value: make([]byte, valueBytes)}}}}
+}
+
+func TestLRUEviction(t *testing.T) {
+	one := Size(rec(1000))
+	c := New(3 * one)
+	for r := Revision(1); r <= 3; r++ {
+		c.Put(r, rec(1000))
+	}
+	if c.Len() != 3 || c.Bytes() != 3*one {
+		t.Fatalf("len %d bytes %d", c.Len(), c.Bytes())
+	}
+	c.Get(1) // 1 is now most recent; 2 is the oldest
+	c.Put(4, rec(1000))
+	if c.Has(2) {
+		t.Error("revision 2 should have been evicted (least recently used)")
+	}
+	for _, r := range []Revision{1, 3, 4} {
+		if !c.Has(r) {
+			t.Errorf("revision %d should be cached", r)
+		}
+	}
+	if c.Bytes() > 3*one {
+		t.Errorf("over budget: %d > %d", c.Bytes(), 3*one)
+	}
+
+	// Replacing a record adjusts the accounting.
+	c.Put(4, rec(10))
+	if c.Bytes() != 2*one+Size(rec(10)) {
+		t.Errorf("bytes after replace = %d", c.Bytes())
+	}
+	// A record larger than the budget is not cached and evicts nothing.
+	c.Put(5, rec(100_000))
+	if c.Has(5) || c.Len() != 3 {
+		t.Errorf("oversized record was cached, or evicted others: len %d", c.Len())
+	}
+	c.Remove(1)
+	if c.Has(1) || c.Len() != 2 {
+		t.Errorf("remove failed: len %d", c.Len())
+	}
+}
+
+func TestUnbounded(t *testing.T) {
+	c := New(0)
+	for r := Revision(1); r <= 1000; r++ {
+		c.Put(r, rec(100))
+	}
+	if c.Len() != 1000 {
+		t.Fatalf("unbounded cache evicted: len %d", c.Len())
+	}
+}

--- a/pkg/persistence/tieredlog/tiered_log.go
+++ b/pkg/persistence/tieredlog/tiered_log.go
@@ -53,6 +53,10 @@ type Options struct {
 	// FlushInterval is how often the fast tier is drained to the archive
 	// tier. Defaults to DefaultFlushInterval.
 	FlushInterval time.Duration
+	// RetainFastTier keeps archived records in the fast tier instead of
+	// pruning them, so that every read is served locally and the archive is
+	// only read to recover. The fast tier then grows until it is compacted.
+	RetainFastTier bool
 }
 
 // TieredLog is a Log that commits to a fast tier and asynchronously drains to
@@ -61,7 +65,8 @@ type TieredLog struct {
 	fast    persistence.Log
 	archive persistence.Log
 
-	flushInterval time.Duration
+	flushInterval  time.Duration
+	retainFastTier bool
 
 	// mu guards the drain/prune cycle against concurrent reads: pruning the
 	// fast tier must not race with a merged read that has finished the archive
@@ -91,11 +96,12 @@ func NewTieredLog(ctx context.Context, fast persistence.Log, archive persistence
 	}
 
 	t := &TieredLog{
-		fast:          fast,
-		archive:       archive,
-		flushInterval: flushInterval,
-		stopCh:        make(chan struct{}),
-		doneCh:        make(chan struct{}),
+		fast:           fast,
+		archive:        archive,
+		flushInterval:  flushInterval,
+		retainFastTier: options.RetainFastTier,
+		stopCh:         make(chan struct{}),
+		doneCh:         make(chan struct{}),
 	}
 
 	if err := t.bootstrap(ctx); err != nil {
@@ -193,7 +199,7 @@ func (t *TieredLog) Flush(ctx context.Context) error {
 	}
 
 	archivedThrough := archiveRevision + Revision(len(records))
-	if truncater, ok := t.fast.(persistence.Truncater); ok {
+	if truncater, ok := t.fast.(persistence.Truncater); ok && !t.retainFastTier {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 		if err := truncater.Truncate(ctx, archivedThrough); err != nil {

--- a/pkg/workload/report.go
+++ b/pkg/workload/report.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -46,6 +47,10 @@ type Report struct {
 
 	// ErrorSamples lists distinct errors seen and how often.
 	ErrorSamples map[string]int64 `json:"errorSamples,omitempty"`
+
+	// HeapInuseBytes is the Go heap in use at the end of the phase, for
+	// the process running the report (the server too, when in-process).
+	HeapInuseBytes uint64 `json:"heapInuseBytes"`
 }
 
 // OpReport summarizes one op label.
@@ -139,6 +144,9 @@ func (r *Runner) report(phase string, stats *Stats, expected map[string]float64)
 			Lag:              latencyReport(&ws.Lag),
 		}
 	}
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	rep.HeapInuseBytes = mem.HeapInuse
 	if len(stats.errs) > 0 {
 		rep.ErrorSamples = map[string]int64{}
 		for msg, n := range stats.errs {
@@ -151,8 +159,8 @@ func (r *Runner) report(phase string, stats *Stats, expected map[string]float64)
 // Text renders the report as a table.
 func (r *Report) Text() string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "== %s: %d nodes, %d pods (%d keys), %s, %d ops (%.0f/s), %d errors\n",
-		r.Phase, r.Nodes, r.Pods, r.Keys, r.Duration.Round(time.Millisecond), r.TotalOps, r.TotalRate, r.Errors)
+	fmt.Fprintf(&sb, "== %s: %d nodes, %d pods (%d keys), %s, %d ops (%.0f/s), %d errors, heap %.0f MB\n",
+		r.Phase, r.Nodes, r.Pods, r.Keys, r.Duration.Round(time.Millisecond), r.TotalOps, r.TotalRate, r.Errors, float64(r.HeapInuseBytes)/(1<<20))
 	tw := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "op\tcount\terrors\tconflicts\trate/s\texpected/s\tp50\tp90\tp99\tp99.9\tmax")
 	labels := make([]string, 0, len(r.Ops))


### PR DESCRIPTION
## Summary

**Stacked on #49** (which is now stacked on #45 → #44; merge in order with "delete branch" and GitHub retargets each).

The index already only holds `key → revisions`; what kept values in RAM was that every backend cached all of them — `memorylog` by nature, `gcslog` via an *unbounded* record cache filled on every commit — while `filesystemlog` re-read whole batches. This makes the file log a real value store with an in-memory working set:

- **`filesystemlog`**: keeps in memory only the file index, each record's byte span within its file (from the codec at commit time; rebuilt by a varint scan on first use for files that predate the process), and a **byte-budgeted LRU** of recently written/read records (`pkg/persistence/recordcache`). A miss is one positioned read of exactly that record's bytes plus one decode. `filesystem://dir?cache=64MB` (default 256 MB).
- **`gcslog`**: same bounded cache instead of the unbounded map (`gs://…?cache=…`), with concurrent fetches of one batch coalesced.
- **`tieredlog`**: `retain=true` keeps archived records in the fast tier instead of pruning, so reads stay local and the archive is only read to recover (the local tier then grows until compaction — the next item).
- **bench**: reports heap in use per phase.

Only the sizes matter to the storage engine, so the cache measures records by key+value bytes plus a per-event overhead.

## Test plan

- [x] `recordcache`: LRU order, byte accounting on replace, oversized records not cached, remove, unbounded mode
- [x] `logcodec.Offsets`/`DecodeMessage` round-trip; truncated input rejected
- [x] `TestFilesystemLog_TinyCache` and `TestGCSLogWithEmulatorTinyCache`: the full log conformance suites with a 1-byte cache, so every read goes to disk / the emulator
- [x] `TestFilesystemLog_ReadsAfterRestart`: reopened log reads single records from files it didn't write
- [x] `go test -race ./pkg/persistence/...`; storage, workload, api, e2e/stress packages

## 100k nodes (with #44/#45/#47/#49; nodes only; 512 workers; 30 s steady)

| | `memory://` | `filesystem://?cache=64MB` |
|---|---|---|
| heap after populate (200k keys) | 517 MB | **248 MB** |
| heap after 30 s steady (300k more records) | **999 MB, growing ~16 MB/s** | **255 MB, flat** |
| lease writes/s (need 10,000) | 9,964 | 9,958 |
| write p50 | 7.1 ms | 29.5 ms (this box's fsync; see #49) |
| populate | 18,082/s | 13,289/s |
| on disk | — | 636 MB |

Memory is bounded by the working set (index + 64 MB cache + client state in the same process) instead of growing with history. The disk now grows instead — compaction is the next item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek

