### PR TITLE
memorylog: the file log over a temporary directory

### DIFF
--- a/cmd/cloud-etcd-bench/main.go
+++ b/cmd/cloud-etcd-bench/main.go
@@ -16,7 +16,7 @@
 // nodes against cloudetcd, without running kube-apiserver or any nodes.
 //
 //	cloud-etcd-bench run -nodes 1000 -pods-per-node 30 -duration 2m
-//	cloud-etcd-bench run -nodes 100 -log 'memory://?commitLatency=50ms' -phases populate,steady,list-storm
+//	cloud-etcd-bench run -nodes 100 -log filesystem:///var/tmp/bench -phases populate,steady,list-storm
 //	cloud-etcd-bench run -endpoint 127.0.0.1:2379 -nodes 100
 //	cloud-etcd-bench run -nodes 100 -node-images 50 -pod-containers 3
 //	cloud-etcd-bench analyze recording.jsonl
@@ -95,7 +95,7 @@ func runBench(ctx context.Context, args []string) error {
 
 	duration := fs.Duration("duration", time.Minute, "Duration of the steady-state phase")
 	phases := fs.String("phases", "populate,steady", "Comma-separated phases to run: populate, steady, list-storm")
-	logURI := fs.String("log", "memory://", "Log URI for the in-process server (e.g. memory://?commitLatency=50ms, filesystem:///tmp/log)")
+	logURI := fs.String("log", "memory://", "Log URI for the in-process server (memory:// is a temporary directory; filesystem:///path; gs://bucket/prefix)")
 	endpoint := fs.String("endpoint", "", "Run against this etcd endpoint instead of starting an in-process server")
 	workers := fs.Int("workers", 64, "Concurrent requests in flight")
 	blobs := fs.String("blobs", "kube", "Values to write: 'kube' (generated Kubernetes objects encoded as the apiserver stores them), 'synthetic' (random bytes of captured sizes), or a directory of captured blobs (see extract-blobs)")

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -28,8 +28,8 @@ endpoint) and drives it with the traffic of a cluster of the given size:
 # 1,000 nodes with 30 pods each, 2 minutes of steady state
 go run ./cmd/cloud-etcd-bench run -nodes 1000 -pods-per-node 30 -duration 2m
 
-# Emulate an object-store backend (a GCS conditional write is ~50ms) without one
-go run ./cmd/cloud-etcd-bench run -nodes 1000 -log 'memory://?commitLatency=50ms'
+# On a real directory (memory:// is a temporary directory removed at exit)
+go run ./cmd/cloud-etcd-bench run -nodes 1000 -log filesystem:///var/tmp/bench
 
 # All phases, JSON output, CPU profile
 go run ./cmd/cloud-etcd-bench run -nodes 100 -phases populate,steady,list-storm -o json -cpuprofile cpu.prof
@@ -101,7 +101,7 @@ up. It is skipped unless `RUN_STRESS` is set:
 
 ```bash
 RUN_STRESS=1 go test ./tests/stress -v
-RUN_STRESS=1 STRESS_NODES=1000 STRESS_PODS_PER_NODE=10 STRESS_DURATION=1m STRESS_LOG='memory://?commitLatency=20ms' go test ./tests/stress -v
+RUN_STRESS=1 STRESS_NODES=1000 STRESS_PODS_PER_NODE=10 STRESS_DURATION=1m STRESS_LOG=filesystem:///var/tmp/stress go test ./tests/stress -v
 ```
 
 ## Capturing a template from a real kube-apiserver

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -63,7 +63,9 @@ type FilesystemLog struct {
 	mu           sync.RWMutex
 	dir          string
 	lastRevision Revision
-	listener     LogListener
+	// removeOnClose deletes dir when the log is closed (see NewTempLog).
+	removeOnClose bool
+	listener      LogListener
 
 	// logFiles is an in-memory index of log files, sorted by firstRevision
 	logFiles []logFileMeta
@@ -85,6 +87,24 @@ var _ persistence.Truncater = &FilesystemLog{}
 // NewFilesystemLog creates a new filesystem-backed log with default Options.
 func NewFilesystemLog(dir string) (*FilesystemLog, error) {
 	return NewFilesystemLogWithOptions(dir, Options{})
+}
+
+// NewTempLog creates a log in a new temporary directory that is removed when
+// the log is closed. It is the log for tests and benchmarks: a real file log
+// (batching, encoding, fsync, record offsets, the record cache) on real
+// files, so anything that works here works on disk.
+func NewTempLog(opts Options) (*FilesystemLog, error) {
+	dir, err := os.MkdirTemp("", "cloudetcd-log-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary log directory: %w", err)
+	}
+	log, err := NewFilesystemLogWithOptions(dir, opts)
+	if err != nil {
+		os.RemoveAll(dir)
+		return nil, err
+	}
+	log.removeOnClose = true
+	return log, nil
 }
 
 // NewFilesystemLogWithOptions creates a new filesystem-backed log.
@@ -429,7 +449,12 @@ func (f *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 
 // Close closes the log and releases any resources
 func (f *FilesystemLog) Close() error {
-	// For filesystem implementation, there's nothing to clean up
+	if err := f.batching.Close(); err != nil {
+		return err
+	}
+	if f.removeOnClose {
+		return os.RemoveAll(f.dir)
+	}
 	return nil
 }
 

--- a/pkg/persistence/logfactory/logfactory.go
+++ b/pkg/persistence/logfactory/logfactory.go
@@ -53,17 +53,8 @@ func NewLog(ctx context.Context, uri string) (persistence.Log, error) {
 		}
 		return gcslog.NewGCSLogWithOptions(ctx, u.Host, strings.TrimPrefix(u.Path, "/"), gcslog.Options{CacheBytes: cacheBytes})
 	case "memory":
-		// memory://?commitLatency=50ms emulates an object-store backend's
-		// commit round-trip on top of the in-memory log.
-		var opts []memorylog.Option
-		if v := u.Query().Get("commitLatency"); v != "" {
-			d, err := time.ParseDuration(v)
-			if err != nil {
-				return nil, fmt.Errorf("parsing commitLatency %q: %w", v, err)
-			}
-			opts = append(opts, memorylog.WithCommitLatency(d))
-		}
-		return memorylog.New(opts...), nil
+		// A throwaway log in a temporary directory, removed on Close.
+		return memorylog.New(), nil
 	case "tiered":
 		return newTieredLog(ctx, u)
 	default:

--- a/pkg/persistence/memorylog/memory_log.go
+++ b/pkg/persistence/memorylog/memory_log.go
@@ -12,174 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package memorylog provides a throwaway log for tests and benchmarks: the
+// file log over a temporary directory that is removed on Close.
 package memorylog
 
 import (
-	"context"
-	"fmt"
-	"sync"
-	"time"
-
-	"justinsb.com/cloudetcd/pkg/persistence"
-	"justinsb.com/cloudetcd/pkg/persistence/batch"
-	"k8s.io/klog/v2"
+	"justinsb.com/cloudetcd/pkg/persistence/filesystemlog"
 )
 
-type Revision = persistence.Revision
-type LogRecord = persistence.LogRecord
-type LogListener = persistence.LogListener
-type TxnBatch = batch.TxnBatch
+// MemoryLog is a file log over a temporary directory.
+type MemoryLog = filesystemlog.FilesystemLog
 
-// MemoryLog is a memory-backed implementation of the Log interface
-type MemoryLog struct {
-	batching *batch.Batching
-
-	mu sync.RWMutex
-
-	records      []*LogRecord
-	lastRevision Revision // Atomic counter for revision numbers
-
-	listener LogListener
-
-	// commitLatency is an artificial delay applied to each batch commit.
-	commitLatency time.Duration
-}
-
-var _ persistence.Log = &MemoryLog{}
-var _ persistence.BatchAppender = &MemoryLog{}
-
-// Option configures a MemoryLog.
-type Option func(*MemoryLog)
-
-// WithCommitLatency makes every batch commit take at least d. It emulates the
-// round-trip of an object-store backend (a GCS conditional write is on the
-// order of tens of milliseconds) without needing one, so that batching
-// behaviour under realistic commit latency can be benchmarked offline.
-func WithCommitLatency(d time.Duration) Option {
-	return func(l *MemoryLog) { l.commitLatency = d }
-}
-
-// New creates a new memory-backed log
-func New(opts ...Option) *MemoryLog {
-	log := &MemoryLog{
-		lastRevision: 0,
+// New creates a new log over a fresh temporary directory.
+func New() *MemoryLog {
+	log, err := filesystemlog.NewTempLog(filesystemlog.Options{})
+	if err != nil {
+		panic(err)
 	}
-	for _, opt := range opts {
-		opt(log)
-	}
-
-	// No replay is possible here
-
-	log.batching = batch.NewBatching(log.lastRevision, log.commitBatch)
 	return log
-}
-
-// Append adds a new record to the log and returns the revision number
-func (l *MemoryLog) Append(ctx context.Context, logRecord *LogRecord, txnMeta *persistence.TxnMeta) (Revision, bool, error) {
-	return l.batching.Add(ctx, logRecord, txnMeta)
-}
-
-// AppendBatch appends a contiguous range of records starting at lastRevision+1, preserving revisions.
-func (l *MemoryLog) AppendBatch(ctx context.Context, lastRevision Revision, records []*LogRecord) (bool, error) {
-	return l.batching.AddBatch(ctx, lastRevision, records)
-}
-
-// commitBatch "writes" a batch (there is nothing to write; the optional
-// commit latency stands in for a backend round-trip) and returns the commit
-// that publishes it.
-func (l *MemoryLog) commitBatch(ctx context.Context, lastLogPosition Revision, b *batch.BatchCommit) (batch.Commit, error) {
-	if len(b.Transactions) == 0 {
-		return nil, fmt.Errorf("batch contains no transactions")
-	}
-
-	if l.commitLatency > 0 {
-		select {
-		case <-time.After(l.commitLatency):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-	return &memoryCommit{log: l, lastLogPosition: lastLogPosition, batch: b}, nil
-}
-
-type memoryCommit struct {
-	log             *MemoryLog
-	lastLogPosition Revision
-	batch           *batch.BatchCommit
-}
-
-func (c *memoryCommit) Publish() {
-	l := c.log
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.lastRevision != c.lastLogPosition {
-		// Batching publishes in order; this cannot happen.
-		panic(fmt.Sprintf("batch published out of order: expected to publish after %d, log is at %d", c.lastLogPosition, l.lastRevision))
-	}
-	startRevision := l.lastRevision + 1
-	for _, txn := range c.batch.Transactions {
-		l.lastRevision++
-		l.records = append(l.records, txn.LogRecord)
-	}
-	if l.listener != nil {
-		l.listener.OnLogEntry(l.lastRevision)
-	}
-	klog.V(2).Infof("Executed batch of %d transactions, revisions %d-%d",
-		len(c.batch.Transactions), startRevision, l.lastRevision)
-}
-
-// GetCurrentRevision returns the current revision number
-func (m *MemoryLog) GetCurrentRevision(ctx context.Context) (Revision, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.lastRevision, nil
-}
-
-// Read reads records from the log starting from the given revision
-func (m *MemoryLog) Read(ctx context.Context, fromRevision Revision, callback func(Revision, *LogRecord) bool) error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	for i, record := range m.records {
-		revision := Revision(i + 1)
-		if revision >= fromRevision {
-			if !callback(revision, record) {
-				break
-			}
-		}
-	}
-
-	return nil
-}
-
-// Close closes the log and releases any resources
-func (m *MemoryLog) Close() error {
-	if err := m.batching.Close(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// GetLogEntry returns the log entry for the given revision
-func (m *MemoryLog) GetLogEntry(revision Revision) (*LogRecord, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if revision <= 0 || int(revision) > len(m.records) {
-		klog.V(2).Infof("log entry not found for revision %d, records length is %d", revision, len(m.records))
-		return nil, fmt.Errorf("log entry not found for revision %d", revision)
-	}
-
-	record := m.records[revision-1]
-
-	return record, nil
-}
-
-// SetListener sets the log listener
-func (m *MemoryLog) SetListener(listener LogListener) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.listener = listener
 }

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"sync"
 	"testing"
-	"time"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 
@@ -32,9 +31,7 @@ import (
 // the Else Range showing the winner's value) rather than error or overwrite.
 func TestConcurrentConditionalUpdatesSerialize(t *testing.T) {
 	ctx := t.Context()
-	// A commit latency makes the batching window wide enough that the racing
-	// transactions land in the same batch, which is the case that matters.
-	store, err := NewMemoryStorage(memorylog.New(memorylog.WithCommitLatency(20 * time.Millisecond)))
+	store, err := NewMemoryStorage(memorylog.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +104,7 @@ func TestConcurrentConditionalUpdatesSerialize(t *testing.T) {
 // revision each response reported, with the log and index agreeing.
 func TestConcurrentWritesToDistinctKeys(t *testing.T) {
 	ctx := t.Context()
-	store, err := NewMemoryStorage(memorylog.New(memorylog.WithCommitLatency(20 * time.Millisecond)))
+	store, err := NewMemoryStorage(memorylog.New())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

`memorylog` is no longer a separate implementation. `memorylog.New()` is `filesystemlog.NewTempLog()`: a log in a fresh temporary directory, removed on `Close`, fsynced like any other. Every test and benchmark that uses `memory://` (storage, API, e2e harness, stress, the bench) now runs the real batching, encoding, fsync, record-offset and record-cache code on real files — which is also what mmap will need.

Removed:
- `pkg/persistence/memorylog/memory_log.go`'s own implementation (~150 lines);
- the `commitLatency` knob (`memory://?commitLatency=`, `WithCommitLatency`): it emulated an object store on the commit path while batching/pipelining were being fixed, and the tiered log is the intended production shape anyway. Docs and the bench's help text updated.

(An earlier revision of this PR introduced an `FS` interface with a map-backed implementation; that's gone — one real implementation didn't justify the indirection, and mmap wants an `*os.File`, not an interface.)

## Test plan

- [x] `go test -race ./pkg/persistence/...` — the memorylog suite now runs the file log on a temp dir
- [x] `go test ./...` 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
