### PR TITLE
watch: send several revisions per WatchResponse when a watcher is behind

### DIFF
--- a/cmd/cloud-etcd-bench/main.go
+++ b/cmd/cloud-etcd-bench/main.go
@@ -152,8 +152,10 @@ func runBench(ctx context.Context, args []string) error {
 	}
 
 	addr := *endpoint
+	var srv *inprocess.Server
 	if addr == "" {
-		srv, err := inprocess.Start(ctx, *logURI)
+		var err error
+		srv, err = inprocess.Start(ctx, *logURI)
 		if err != nil {
 			return err
 		}
@@ -171,6 +173,9 @@ func runBench(ctx context.Context, args []string) error {
 	runner, err := workload.NewRunner(cfg, client, *workers)
 	if err != nil {
 		return err
+	}
+	if srv != nil {
+		runner.WatcherStatus = srv.Store.Watchers
 	}
 
 	fmt.Fprintf(os.Stderr, "model: %d nodes, %d pods, %d keys; blobs %v\n", cfg.Nodes, cfg.Pods(), cfg.Keys(), cfg.Blobs.Sizes())

--- a/pkg/storage/memorystorage/watch.go
+++ b/pkg/storage/memorystorage/watch.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -76,6 +77,7 @@ func (m *MemoryStorage) Watch(ctx context.Context, req *etcdserverpb.WatchCreate
 	}
 
 	w.stateCond = sync.NewCond(&w.stateMutex)
+	w.delivered.Store(uint64(watchDoneRevision))
 
 	if len(w.req.GetRangeEnd()) > 0 {
 		if bytes.Equal(w.req.GetRangeEnd(), []byte{0}) {
@@ -123,6 +125,8 @@ type memoryWatcher struct {
 	callback func(event *etcdserverpb.WatchResponse) error
 
 	watchDoneRevision Revision
+	// delivered mirrors watchDoneRevision for readers on other goroutines.
+	delivered atomic.Uint64
 
 	stateMutex sync.Mutex
 	stateCond  *sync.Cond
@@ -166,29 +170,53 @@ func (w *memoryWatcher) Run(ctx context.Context) error {
 		logPosition := w.logPosition
 		w.stateMutex.Unlock()
 
-		for {
-			if w.watchDoneRevision >= logPosition {
-				break
+		for w.watchDoneRevision < logPosition {
+			// Send one response for as many revisions as are ready, up to a
+			// bound: when the watcher is behind, one gRPC message per
+			// revision is what limits it (as in etcd, a WatchResponse may
+			// carry events from several revisions; each event has its own
+			// ModRevision, and the header carries the last).
+			var events []*mvccpb.Event
+			last := w.watchDoneRevision
+			for last < logPosition && last-w.watchDoneRevision < maxRevisionsPerResponse && len(events) < maxEventsPerResponse {
+				next := last + 1
+				evs, err := w.collect(next)
+				if err != nil {
+					log.Error(err, "failed to read events in watcher", "watcher.id", w.id, "watchPosition", next)
+					return err
+				}
+				events = append(events, evs...)
+				last = next
 			}
-
-			nextRevision := w.watchDoneRevision + 1
-			if err := w.send(ctx, nextRevision); err != nil {
-				log.Error(err, "failed to send event in watcher", "watcher.id", w.id, "watchPosition", nextRevision)
-				return err
+			if len(events) > 0 {
+				if err := w.callback(&etcdserverpb.WatchResponse{
+					Header:  createHeader(last),
+					WatchId: w.id,
+					Events:  events,
+				}); err != nil {
+					log.Error(err, "failed to send events in watcher", "watcher.id", w.id, "watchPosition", last)
+					return err
+				}
 			}
-			w.watchDoneRevision = nextRevision
+			w.watchDoneRevision = last
+			w.delivered.Store(uint64(last))
 		}
 	}
 }
 
-func (w *memoryWatcher) send(ctx context.Context, pos Revision) error {
-	// log := klog.FromContext(ctx)
+// maxRevisionsPerResponse and maxEventsPerResponse bound one WatchResponse
+// when a watcher is catching up.
+const (
+	maxRevisionsPerResponse = 256
+	maxEventsPerResponse    = 512
+)
 
-	// Check if this watcher should receive this event
-
+// collect returns the events of revision pos that this watcher should
+// receive, in the form it sends them.
+func (w *memoryWatcher) collect(pos Revision) ([]*mvccpb.Event, error) {
 	events, err := w.storage.getWatchEvent(pos)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var sendEvents []*mvccpb.Event
@@ -239,10 +267,8 @@ func (w *memoryWatcher) send(ctx context.Context, pos Revision) error {
 	}
 
 	if len(sendEvents) == 0 {
-		return nil
+		return nil, nil
 	}
-
-	// log.Info("sending events for watcher", "watcher.key", w.req.GetKey(), "watcher.rangeEnd", w.req.GetRangeEnd(), "watcher.filters", w.req.GetFilters(), "watcher.prevKv", w.req.PrevKv, "watcher.id", w.id, "events", sendEvents)
 
 	if !w.req.PrevKv {
 		sendEventsWithoutPrevKv := make([]*mvccpb.Event, 0, len(sendEvents))
@@ -257,18 +283,7 @@ func (w *memoryWatcher) send(ctx context.Context, pos Revision) error {
 		sendEvents = sendEventsWithoutPrevKv
 	}
 
-	resp := &etcdserverpb.WatchResponse{
-		Header:  createHeader(pos),
-		WatchId: w.id,
-		Events:  sendEvents,
-	}
-
-	// klog.Infof("broadcasting event %v to watcher %d", resp, w.id)
-	if err := w.callback(resp); err != nil {
-		return err
-	}
-
-	return nil
+	return sendEvents, nil
 }
 
 func (w *MemoryStorage) getWatchEvent(pos Revision) ([]*mvccpb.Event, error) {
@@ -281,4 +296,21 @@ func (w *MemoryStorage) getWatchEvent(pos Revision) ([]*mvccpb.Event, error) {
 	}
 
 	return logEntry.Events, nil
+}
+
+// Watchers reports every open watcher's position, for diagnostics.
+func (m *MemoryStorage) Watchers() []storage.WatcherStatus {
+	m.watcherMu.RLock()
+	defer m.watcherMu.RUnlock()
+	var out []storage.WatcherStatus
+	for _, w := range m.watchers {
+		w.stateMutex.Lock()
+		closed, head := w.closed, w.logPosition
+		w.stateMutex.Unlock()
+		if closed {
+			continue
+		}
+		out = append(out, storage.WatcherStatus{ID: w.id, Delivered: Revision(w.delivered.Load()), Head: head})
+	}
+	return out
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -47,6 +47,14 @@ type Watcher interface {
 	Run(ctx context.Context) error
 }
 
+// WatcherStatus describes how far a watcher has got: Delivered is the last
+// revision it has sent to its client, Head the log revision it knows about.
+type WatcherStatus struct {
+	ID        int64
+	Delivered Revision
+	Head      Revision
+}
+
 // Storage is the interface for the underlying storage layer.
 type Storage interface {
 	// GetCurrentRevision returns the current revision of the log.

--- a/pkg/workload/inprocess/inprocess.go
+++ b/pkg/workload/inprocess/inprocess.go
@@ -33,6 +33,8 @@ import (
 type Server struct {
 	// Addr is the host:port the server listens on.
 	Addr string
+	// Store is the server's storage, for diagnostics.
+	Store *memorystorage.MemoryStorage
 
 	server *api.Server
 	cancel context.CancelFunc
@@ -61,6 +63,7 @@ func Start(ctx context.Context, logURI string, opts ...api.Option) (*Server, err
 	ctx, cancel := context.WithCancel(ctx)
 	s := &Server{
 		Addr:   addr,
+		Store:  store,
 		server: api.NewServer(store, opts...),
 		cancel: cancel,
 		done:   make(chan error, 1),

--- a/pkg/workload/report.go
+++ b/pkg/workload/report.go
@@ -44,6 +44,10 @@ type Report struct {
 
 	// Watches is keyed by resource prefix.
 	Watches map[string]*WatchReport `json:"watches,omitempty"`
+	// ServerWatchLagRevisions is how far behind the log head the server-side
+	// watchers were, in revisions, sampled twice a second (in-process
+	// servers only).
+	ServerWatchLagRevisions *LatencyReport `json:"serverWatchLagRevisions,omitempty"`
 
 	// ErrorSamples lists distinct errors seen and how often.
 	ErrorSamples map[string]int64 `json:"errorSamples,omitempty"`
@@ -135,6 +139,10 @@ func (r *Runner) report(phase string, stats *Stats, expected map[string]float64)
 		lr := latencyReport(&stats.SchedulingLag)
 		rep.SchedulingLag = &lr
 	}
+	if stats.ServerWatchLag.Count() > 0 {
+		lr := latencyReport(&stats.ServerWatchLag)
+		rep.ServerWatchLagRevisions = &lr
+	}
 	for label, ws := range stats.watches {
 		rep.Watches[label] = &WatchReport{
 			Events:           ws.Events.Load(),
@@ -183,6 +191,10 @@ func (r *Report) Text() string {
 		l := r.SchedulingLag
 		fmt.Fprintf(&sb, "scheduling lag: p50 %s  p90 %s  p99 %s  max %s (ops started this long after they were due)\n",
 			fmtDur(l.P50), fmtDur(l.P90), fmtDur(l.P99), fmtDur(l.Max))
+	}
+	if l := r.ServerWatchLagRevisions; l != nil {
+		fmt.Fprintf(&sb, "server watch lag: p50 %d  p90 %d  p99 %d  max %d revisions behind the log head (sampled twice a second)\n",
+			int64(l.P50), int64(l.P90), int64(l.P99), int64(l.Max))
 	}
 	if len(r.Watches) > 0 {
 		tw = tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)

--- a/pkg/workload/runner.go
+++ b/pkg/workload/runner.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"justinsb.com/cloudetcd/pkg/storage"
 )
 
 // Runner drives a cluster's worth of traffic at an etcd endpoint. Its phases
@@ -43,6 +45,10 @@ type Runner struct {
 	// (hundreds), all multiplexed on one connection, which is what this
 	// reproduces.
 	Workers int
+	// WatcherStatus, if set, reports the server's watchers; the steady phase
+	// samples it to report how far behind the log head the server-side
+	// watchers get, separately from what the client receives.
+	WatcherStatus func() []storage.WatcherStatus
 
 	exec   *executor
 	state  *stateMap
@@ -217,6 +223,14 @@ func (r *Runner) Steady(ctx context.Context, d time.Duration) (*Report, error) {
 		}()
 	}
 
+	if r.WatcherStatus != nil {
+		watchers.Add(1)
+		go func() {
+			defer watchers.Done()
+			r.sampleWatchers(watchCtx, stats)
+		}()
+	}
+
 	p := newPool(schedCtx, ctx, r.Workers, stats)
 	var loops sync.WaitGroup
 	loop := func(fn func()) {
@@ -330,4 +344,25 @@ func (r *Runner) ListStorm(ctx context.Context, concurrency, rounds int) (*Repor
 	}
 	wg.Wait()
 	return r.report("list-storm", stats, nil), ctx.Err()
+}
+
+// sampleWatchers records, twice a second, how far behind the log head each
+// server-side watcher is.
+func (r *Runner) sampleWatchers(ctx context.Context, stats *Stats) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		for _, w := range r.WatcherStatus() {
+			lag := int64(w.Head) - int64(w.Delivered)
+			if lag < 0 {
+				lag = 0
+			}
+			stats.ServerWatchLag.Observe(time.Duration(lag)) // in revisions, not time
+		}
+	}
 }

--- a/pkg/workload/stats.go
+++ b/pkg/workload/stats.go
@@ -138,6 +138,9 @@ type Stats struct {
 	// model said it was due. It grows without bound when the server cannot
 	// keep up, which makes it the primary "is the server keeping up" signal.
 	SchedulingLag Histogram
+	// ServerWatchLag samples, in revisions (stored as Duration units), how
+	// far behind the log head the server-side watchers were.
+	ServerWatchLag Histogram
 }
 
 const maxErrorSamples = 32


### PR DESCRIPTION
## Summary

Pins down the watch-delivery variance and removes the ceiling it exposed.

**Instrumentation.** Storage now reports each open watcher's delivered position vs. the log head (`MemoryStorage.Watchers()`); the bench samples it twice a second during steady state and prints `server watch lag`, so server-side lag is measured directly rather than inferred from client-side counts.

**Finding.** Run alone, delivery was already complete (450,003 of 450,000 events at 100k nodes); the earlier 200–1,500 events/s figures were contention from benchmarks run concurrently on one machine. But at 100k nodes the watcher sat **~1,100 revisions (~110 ms) behind, peaking at ~3,800**, with client-side p99 150–350 ms, while at 10k it was a constant 13 (one batch). One goroutine sending **one gRPC message per revision** saturates right around 10k events/s.

**Fix.** As etcd does, a `WatchResponse` may carry the events of several revisions (each event has its own `ModRevision`; the header carries the last). A watcher that has fallen behind now catches up in responses of up to 256 revisions / 512 events.

## Result (100k nodes, 512 workers, `memory://`, run alone)

| | before | after |
|---|---|---|
| server watch lag (revisions) p50 / max | 1,100 / 3,800 | **111 / 111** (one commit batch — the floor) |
| client delivery p99 / max | 149 ms / 268 ms | **43 ms / 94 ms** |
| events delivered | 450,003 | 449,998 (all) |
| writes/s | 9,973 | 9,972 |

## Test plan

- [x] `go test ./pkg/storage/memorystorage ./pkg/api ./pkg/workload`
- [x] `RUN_E2E=1` real kube-apiserver smoke test (its watch cache receives the multi-revision responses)
- [x] `-race` on `pkg/api`; `memorystorage` under `-race` still hits the teardown flake that #24 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
