### PR TITLE
compaction: rewrite closed log files keeping only live records

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The project is in early development. Currently implemented:
   - `filesystem:///path` — batches are appended to an active file and fsynced; the file is rotated by size or age
   - `filesystem:///path?archive=gs://bucket/prefix` — every rotated file is uploaded to GCS (with a conditional write, so two writers are detected), and a machine with no local files restores from it
   - `memory://` — a temporary directory removed on exit, for tests and benchmarks
+- **Compaction**: the `Compact` RPC (which kube-apiserver issues every 5 minutes) discards history below the requested revision, keeping the latest version of every key; closed log files are rewritten in the background with only their live records and merged, so disk is bounded by the live data plus recent history
 
 ## Building and Testing
 

--- a/cmd/cloud-etcd-bench/main.go
+++ b/cmd/cloud-etcd-bench/main.go
@@ -268,12 +268,24 @@ func dirBytes(dir string) int64 {
 	var total int64
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		// The log directory should always be readable; a size of 0 in the
+		// report would be quietly wrong.
+		klog.Warningf("reading log directory %s: %v", dir, err)
 		return 0
 	}
 	for _, e := range entries {
-		if info, err := e.Info(); err == nil && !e.IsDir() {
-			total += info.Size()
+		if e.IsDir() {
+			// The log keeps a flat directory of files; a subdirectory is
+			// not ours and is not counted.
+			klog.Warningf("unexpected directory %s in log directory %s", e.Name(), dir)
+			continue
 		}
+		info, err := e.Info()
+		if err != nil {
+			klog.Warningf("sizing log file %s: %v", e.Name(), err)
+			continue
+		}
+		total += info.Size()
 	}
 	return total
 }

--- a/cmd/cloud-etcd-bench/main.go
+++ b/cmd/cloud-etcd-bench/main.go
@@ -176,6 +176,7 @@ func runBench(ctx context.Context, args []string) error {
 	}
 	if srv != nil {
 		runner.WatcherStatus = srv.Store.Watchers
+		runner.LogBytes = func() int64 { return dirBytes(srv.LogDir) }
 	}
 
 	fmt.Fprintf(os.Stderr, "model: %d nodes, %d pods, %d keys; blobs %v\n", cfg.Nodes, cfg.Pods(), cfg.Keys(), cfg.Blobs.Sizes())
@@ -260,4 +261,19 @@ func runExtractBlobs(args []string) error {
 	}
 	fmt.Printf("wrote blobs to %s: %v\n", args[1], b.Sizes())
 	return nil
+}
+
+// dirBytes is the total size of the files in dir.
+func dirBytes(dir string) int64 {
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil && !e.IsDir() {
+			total += info.Size()
+		}
+	}
+	return total
 }

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -96,6 +96,10 @@ The last row matters: 100k nodes is not 100k watches. It is a handful of
 prefix watches each receiving 10k events/s. So the interesting numbers are
 write throughput, watch event throughput and watch lag — not watcher count.
 
+### Compaction
+
+The model issues `Compact` every 5 minutes as the apiserver does (`-compact-interval` shortens that). The server prunes its index to each key's latest version at or below the compaction point, drops deleted keys, and rewrites closed log files in the background keeping only live records (a compacted file is sparse in revision and named by the range it covers). The report's `log … MB on disk` per phase is how to see it: with compaction the log settles at the live set plus one interval's tail; without it the log grows at the write rate.
+
 ## The gated stress test
 
 `tests/stress` runs the same phases against an in-process server and fails

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -322,10 +323,18 @@ func (s *Server) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdse
 
 // Compact implements the Compact RPC method
 func (s *Server) Compact(ctx context.Context, req *etcdserverpb.CompactionRequest) (*etcdserverpb.CompactionResponse, error) {
-	// For now, return success without actual compaction
-	// In a full implementation, we'd need to implement actual compaction logic
+	current, err := s.storage.GetCurrentRevision(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if storage.Revision(req.Revision) > current {
+		return nil, rpctypes.ErrGRPCFutureRev
+	}
+	if _, err := s.storage.Compact(ctx, storage.Revision(req.Revision)); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	return &etcdserverpb.CompactionResponse{
-		Header: s.createHeader(storage.Revision(req.Revision)),
+		Header: s.createHeader(current),
 	}, nil
 }
 

--- a/pkg/bptree/bptree.go
+++ b/pkg/bptree/bptree.go
@@ -47,10 +47,9 @@ type Revision = persistence.Revision
 type BPTree struct {
 	mu   sync.RWMutex
 	root node
-	// emptyKey holds the revisions of the empty key, which has no first byte
-	// to place it in a node.
-	emptyKey          []Revision
-	emptyKeyTombstone bool
+	// emptyKey is the entry for the empty key, which has no first byte to
+	// place it in a node. Its prefix is nil.
+	emptyKey nodeEntry
 	// keys is the number of distinct keys in the index.
 	keys int
 }
@@ -68,16 +67,37 @@ type nodeEntry struct {
 	prefix    []byte
 	revisions []Revision
 	child     *node
-	// tombstone is whether the latest revision is a delete.
+	// tombstone is whether the latest revision is a delete. Only the latest
+	// one needs marking: Compact removes a key whose latest write at or
+	// below the compaction point is a delete, and otherwise keeps an
+	// earlier delete like any other revision (the log keeps the delete
+	// record for as long as the index refers to it), so a put, delete, put
+	// sequence needs nothing more than the latest flag.
 	tombstone bool
+}
+
+// compact trims the entry's revisions for Compact, and reports how many it
+// dropped and whether the key is gone.
+func (e *nodeEntry) compact(through Revision) (dropped int, gone bool) {
+	if e.revisions == nil {
+		return 0, false
+	}
+	kept, dropped, gone := compactRevisions(e.revisions, e.tombstone, through)
+	if gone {
+		e.revisions = nil
+		e.tombstone = false
+	} else {
+		e.revisions = kept
+	}
+	return dropped, gone
 }
 
 // Dump prints the index, for debugging.
 func (t *BPTree) Dump() {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	if t.emptyKey != nil {
-		fmt.Printf("key: (empty), revisions: %v\n", t.emptyKey)
+	if t.emptyKey.revisions != nil {
+		fmt.Printf("key: (empty), revisions: %v\n", t.emptyKey.revisions)
 	}
 	t.root.dump(nil)
 }
@@ -119,26 +139,19 @@ func commonPrefixLen(a, b []byte) int {
 	return n
 }
 
-// AddRevision records that key was written at revision. Revisions for a key
-// are expected to be added in increasing order.
-func (t *BPTree) AddRevision(key []byte, revision Revision) {
-	t.add(key, revision, false)
-}
-
-// AddTombstone records that key was deleted at revision.
-func (t *BPTree) AddTombstone(key []byte, revision Revision) {
-	t.add(key, revision, true)
-}
-
-func (t *BPTree) add(key []byte, revision Revision, tombstone bool) {
+// AddRevision records that key was written at revision: a put, or a delete
+// if tombstone is set. Revisions for a key are expected to be added in
+// increasing order.
+func (t *BPTree) AddRevision(key []byte, revision Revision, tombstone bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if len(key) == 0 {
-		if t.emptyKey == nil {
+		e := &t.emptyKey
+		if e.revisions == nil {
 			t.keys++
 		}
-		t.emptyKey = append(t.emptyKey, revision)
-		t.emptyKeyTombstone = tombstone
+		e.revisions = append(e.revisions, revision)
+		e.tombstone = tombstone
 		return
 	}
 	if t.root.addRevision(key, revision, tombstone) {
@@ -153,20 +166,16 @@ func (t *BPTree) add(key []byte, revision Revision, tombstone bool) {
 func (t *BPTree) Compact(through Revision) (keysRemoved, revisionsDropped int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.emptyKey != nil {
-		kept, dropped, gone := compactRevisions(t.emptyKey, t.emptyKeyTombstone, through)
-		revisionsDropped += dropped
-		if gone {
-			t.emptyKey = nil
-			t.keys--
-			keysRemoved++
-		} else {
-			t.emptyKey = kept
-		}
+	dropped, gone := t.emptyKey.compact(through)
+	revisionsDropped += dropped
+	if gone {
+		keysRemoved++
 	}
 	k, d := t.root.compact(through)
-	t.keys -= k
-	return keysRemoved + k, revisionsDropped + d
+	keysRemoved += k
+	revisionsDropped += d
+	t.keys -= keysRemoved
+	return keysRemoved, revisionsDropped
 }
 
 // compactRevisions trims one key's revisions for Compact.
@@ -189,16 +198,10 @@ func compactRevisions(revisions []Revision, tombstone bool, through Revision) (k
 func (n *node) compact(through Revision) (keysRemoved, revisionsDropped int) {
 	for i := range n.entries {
 		e := &n.entries[i]
-		if e.revisions != nil {
-			kept, dropped, gone := compactRevisions(e.revisions, e.tombstone, through)
-			revisionsDropped += dropped
-			if gone {
-				e.revisions = nil
-				e.tombstone = false
-				keysRemoved++
-			} else {
-				e.revisions = kept
-			}
+		dropped, gone := e.compact(through)
+		revisionsDropped += dropped
+		if gone {
+			keysRemoved++
 		}
 		if e.child != nil {
 			k, d := e.child.compact(through)
@@ -268,7 +271,7 @@ func (t *BPTree) GetLatestRevisionByKey(key []byte, atRevision Revision) (Revisi
 	defer t.mu.RUnlock()
 	var revisions []Revision
 	if len(key) == 0 {
-		revisions = t.emptyKey
+		revisions = t.emptyKey.revisions
 	} else {
 		revisions = t.root.lookup(key)
 	}
@@ -312,8 +315,8 @@ func (n *node) lookup(key []byte) []Revision {
 func (t *BPTree) ListRevisionsByKeyRange(startKey []byte, atRevision Revision, callback func(key []byte, revisions []Revision) bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	if len(startKey) == 0 && t.emptyKey != nil {
-		if !callback(nil, t.emptyKey) {
+	if len(startKey) == 0 && t.emptyKey.revisions != nil {
+		if !callback(nil, t.emptyKey.revisions) {
 			return
 		}
 	}

--- a/pkg/bptree/bptree.go
+++ b/pkg/bptree/bptree.go
@@ -49,7 +49,8 @@ type BPTree struct {
 	root node
 	// emptyKey holds the revisions of the empty key, which has no first byte
 	// to place it in a node.
-	emptyKey []Revision
+	emptyKey          []Revision
+	emptyKeyTombstone bool
 	// keys is the number of distinct keys in the index.
 	keys int
 }
@@ -67,6 +68,8 @@ type nodeEntry struct {
 	prefix    []byte
 	revisions []Revision
 	child     *node
+	// tombstone is whether the latest revision is a delete.
+	tombstone bool
 }
 
 // Dump prints the index, for debugging.
@@ -119,6 +122,15 @@ func commonPrefixLen(a, b []byte) int {
 // AddRevision records that key was written at revision. Revisions for a key
 // are expected to be added in increasing order.
 func (t *BPTree) AddRevision(key []byte, revision Revision) {
+	t.add(key, revision, false)
+}
+
+// AddTombstone records that key was deleted at revision.
+func (t *BPTree) AddTombstone(key []byte, revision Revision) {
+	t.add(key, revision, true)
+}
+
+func (t *BPTree) add(key []byte, revision Revision, tombstone bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if len(key) == 0 {
@@ -126,21 +138,85 @@ func (t *BPTree) AddRevision(key []byte, revision Revision) {
 			t.keys++
 		}
 		t.emptyKey = append(t.emptyKey, revision)
+		t.emptyKeyTombstone = tombstone
 		return
 	}
-	if t.root.addRevision(key, revision) {
+	if t.root.addRevision(key, revision, tombstone) {
 		t.keys++
 	}
 }
 
+// Compact discards history below through: each key keeps its revisions >=
+// through and the latest one below, which is all a read at or after through
+// can observe. A key whose latest revision is a delete at or below through is
+// removed. It returns the number of keys removed and revisions dropped.
+func (t *BPTree) Compact(through Revision) (keysRemoved, revisionsDropped int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.emptyKey != nil {
+		kept, dropped, gone := compactRevisions(t.emptyKey, t.emptyKeyTombstone, through)
+		revisionsDropped += dropped
+		if gone {
+			t.emptyKey = nil
+			t.keys--
+			keysRemoved++
+		} else {
+			t.emptyKey = kept
+		}
+	}
+	k, d := t.root.compact(through)
+	t.keys -= k
+	return keysRemoved + k, revisionsDropped + d
+}
+
+// compactRevisions trims one key's revisions for Compact.
+func compactRevisions(revisions []Revision, tombstone bool, through Revision) (kept []Revision, dropped int, gone bool) {
+	latest := revisions[len(revisions)-1]
+	if tombstone && latest <= through {
+		return nil, len(revisions), true
+	}
+	// Revisions are ascending: keep from the last one <= through onward.
+	i := sort.Search(len(revisions), func(i int) bool { return revisions[i] > through })
+	if i > 0 {
+		i--
+	}
+	if i == 0 {
+		return revisions, 0, false
+	}
+	return append(revisions[:0], revisions[i:]...), i, false
+}
+
+func (n *node) compact(through Revision) (keysRemoved, revisionsDropped int) {
+	for i := range n.entries {
+		e := &n.entries[i]
+		if e.revisions != nil {
+			kept, dropped, gone := compactRevisions(e.revisions, e.tombstone, through)
+			revisionsDropped += dropped
+			if gone {
+				e.revisions = nil
+				e.tombstone = false
+				keysRemoved++
+			} else {
+				e.revisions = kept
+			}
+		}
+		if e.child != nil {
+			k, d := e.child.compact(through)
+			keysRemoved += k
+			revisionsDropped += d
+		}
+	}
+	return keysRemoved, revisionsDropped
+}
+
 // addRevision adds revision for the key that continues with key from this
 // node. It returns true if the key is new.
-func (n *node) addRevision(key []byte, revision Revision) bool {
+func (n *node) addRevision(key []byte, revision Revision, tombstone bool) bool {
 	pos, found := n.find(key[0])
 	if !found {
 		// No entry shares a first byte with the key: a new leaf edge. Clone
 		// the key; callers pass buffers owned by request messages.
-		n.entries = slices.Insert(n.entries, pos, nodeEntry{prefix: bytes.Clone(key), revisions: []Revision{revision}})
+		n.entries = slices.Insert(n.entries, pos, nodeEntry{prefix: bytes.Clone(key), revisions: []Revision{revision}, tombstone: tombstone})
 		return true
 	}
 
@@ -151,13 +227,14 @@ func (n *node) addRevision(key []byte, revision Revision) bool {
 			// The key ends exactly at this entry.
 			isNew := e.revisions == nil
 			e.revisions = append(e.revisions, revision)
+			e.tombstone = tombstone
 			return isNew
 		}
 		// The entry's prefix is a prefix of the key: continue below it.
 		if e.child == nil {
 			e.child = &node{}
 		}
-		return e.child.addRevision(key[common:], revision)
+		return e.child.addRevision(key[common:], revision, tombstone)
 	}
 
 	// The key diverges inside the entry's prefix: split the entry at the
@@ -167,18 +244,21 @@ func (n *node) addRevision(key []byte, revision Revision) bool {
 		prefix:    e.prefix[common:],
 		revisions: e.revisions,
 		child:     e.child,
+		tombstone: e.tombstone,
 	}}}
 	e.prefix = e.prefix[:common:common]
 	e.revisions = nil
+	e.tombstone = false
 	e.child = child
 	if common == len(key) {
 		// The key ends exactly at the split point.
 		e.revisions = []Revision{revision}
+		e.tombstone = tombstone
 		return true
 	}
 	// The key's remainder differs from the old remainder in its first byte,
 	// so it becomes a second edge of the new child.
-	return child.addRevision(key[common:], revision)
+	return child.addRevision(key[common:], revision, tombstone)
 }
 
 // GetLatestRevisionByKey returns the latest revision at which key was

--- a/pkg/bptree/bptree_test.go
+++ b/pkg/bptree/bptree_test.go
@@ -23,9 +23,9 @@ import (
 
 // func TestBPTree_AddRevision(t *testing.T) {
 // 	tree := New()
-// 	tree.AddRevision([]byte("key1"), 1)
-// 	tree.AddRevision([]byte("key2"), 2)
-// 	tree.AddRevision([]byte("key1"), 3)
+// 	tree.AddRevision([]byte("key1"), 1, false)
+// 	tree.AddRevision([]byte("key2"), 2, false)
+// 	tree.AddRevision([]byte("key1"), 3, false)
 
 // 	if len(tree.root.keys) != 2 {
 // 		t.Errorf("expected 2 keys, got %d", len(tree.root.keys))
@@ -55,11 +55,11 @@ import (
 
 func TestBPTree_GetLatestRevisionByKey(t *testing.T) {
 	var tree BPTree
-	tree.AddRevision([]byte("key1"), 1)
-	tree.AddRevision([]byte("key3"), 2)
-	tree.AddRevision([]byte("key5"), 3)
-	tree.AddRevision([]byte("key1"), 4)
-	tree.AddRevision([]byte("key3"), 5)
+	tree.AddRevision([]byte("key1"), 1, false)
+	tree.AddRevision([]byte("key3"), 2, false)
+	tree.AddRevision([]byte("key5"), 3, false)
+	tree.AddRevision([]byte("key1"), 4, false)
+	tree.AddRevision([]byte("key3"), 5, false)
 
 	scenarios := []struct {
 		key          []byte
@@ -98,11 +98,11 @@ func TestBPTree_GetLatestRevisionByKey(t *testing.T) {
 
 func TestBPTree_ListRevisionsByKeyRange(t *testing.T) {
 	var tree BPTree
-	tree.AddRevision([]byte("key1"), 1)
-	tree.AddRevision([]byte("key3"), 2)
-	tree.AddRevision([]byte("key5"), 3)
-	tree.AddRevision([]byte("key1"), 4)
-	tree.AddRevision([]byte("key3"), 5)
+	tree.AddRevision([]byte("key1"), 1, false)
+	tree.AddRevision([]byte("key3"), 2, false)
+	tree.AddRevision([]byte("key5"), 3, false)
+	tree.AddRevision([]byte("key1"), 4, false)
+	tree.AddRevision([]byte("key3"), 5, false)
 
 	{
 		got := make(map[string][]Revision)

--- a/pkg/bptree/radix_test.go
+++ b/pkg/bptree/radix_test.go
@@ -231,3 +231,48 @@ func shuffled(s []string, seed int64) []string {
 	rand.New(rand.NewSource(seed)).Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
 	return out
 }
+
+// TestCompact checks that compaction keeps what a read at or after the
+// compaction revision can observe, drops the rest, and removes keys whose
+// latest revision is a delete below it.
+func TestCompact(t *testing.T) {
+	var tree BPTree
+	tree.AddRevision([]byte("a"), 1)
+	tree.AddRevision([]byte("a"), 5)
+	tree.AddRevision([]byte("a"), 9)
+	tree.AddRevision([]byte("b"), 2)
+	tree.AddTombstone([]byte("b"), 6)
+	tree.AddRevision([]byte("c"), 3)
+	tree.AddTombstone([]byte("c"), 12)
+	tree.AddRevision([]byte("d"), 4)
+	tree.AddRevision([]byte("d"), 11)
+
+	removed, dropped := tree.Compact(8)
+	// b is gone (2 revisions); a drops 1; c and d keep their latest below 8.
+	if removed != 1 || dropped != 3 {
+		t.Fatalf("Compact(8) removed %d keys, dropped %d revisions; want 1, 3", removed, dropped)
+	}
+	if tree.Len() != 3 {
+		t.Fatalf("Len = %d, want 3", tree.Len())
+	}
+	if got, ok := tree.GetLatestRevisionByKey([]byte("a"), 8); !ok || got != 5 {
+		t.Errorf("a at 8 = %d,%v want 5", got, ok)
+	}
+	if _, ok := tree.GetLatestRevisionByKey([]byte("a"), 1); ok {
+		t.Errorf("a at 1 should be gone (compacted)")
+	}
+	if _, ok := tree.GetLatestRevisionByKey([]byte("b"), 100); ok {
+		t.Errorf("b was deleted below the compaction revision and should be gone")
+	}
+	if got, ok := tree.GetLatestRevisionByKey([]byte("c"), 100); !ok || got != 12 {
+		t.Errorf("c = %d,%v want tombstone at 12", got, ok)
+	}
+	var keys []string
+	tree.ListRevisionsByKeyRange(nil, 100, func(key []byte, revisions []Revision) bool {
+		keys = append(keys, string(key)+fmt.Sprint(revisions))
+		return true
+	})
+	if fmt.Sprint(keys) != "[a[5 9] c[3 12] d[4 11]]" {
+		t.Errorf("after compaction: %v", keys)
+	}
+}

--- a/pkg/bptree/radix_test.go
+++ b/pkg/bptree/radix_test.go
@@ -89,12 +89,12 @@ func TestRadixSplitting(t *testing.T) {
 		var tree BPTree
 		var ref reference
 		for i, k := range order {
-			tree.AddRevision([]byte(k), Revision(i+1))
+			tree.AddRevision([]byte(k), Revision(i+1), false)
 			ref.add(k, Revision(i+1))
 		}
 		// Second revisions, in a different order.
 		for i, k := range reverse(order) {
-			tree.AddRevision([]byte(k), Revision(100+i))
+			tree.AddRevision([]byte(k), Revision(100+i), false)
 			ref.add(k, Revision(100+i))
 		}
 		checkAgainst(t, &tree, &ref, starts)
@@ -115,7 +115,7 @@ func TestRadixRandom(t *testing.T) {
 			b[j] = "abc/"[rng.Intn(4)]
 		}
 		k := string(b)
-		tree.AddRevision([]byte(k), Revision(i+1))
+		tree.AddRevision([]byte(k), Revision(i+1), false)
 		ref.add(k, Revision(i+1))
 		if i%100 == 0 {
 			starts = append(starts, k, k+"a", k[:len(k)/2])
@@ -129,7 +129,7 @@ func TestRadixRandom(t *testing.T) {
 func TestKeysAreNotAliased(t *testing.T) {
 	var tree BPTree
 	buf := []byte("/registry/minions/node-1")
-	tree.AddRevision(buf, 1)
+	tree.AddRevision(buf, 1, false)
 	copy(buf, "/registry/minions/node-2")
 	if _, ok := tree.GetLatestRevisionByKey([]byte("/registry/minions/node-1"), 1); !ok {
 		t.Fatal("key changed after the caller reused its buffer")
@@ -157,10 +157,10 @@ func TestBPTree_ManyKeys(t *testing.T) {
 
 	var tree BPTree
 	for rev, i := range perm {
-		tree.AddRevision(keys[i], Revision(rev+1))
+		tree.AddRevision(keys[i], Revision(rev+1), false)
 	}
 	for rev, i := range perm {
-		tree.AddRevision(keys[i], Revision(n+rev+1))
+		tree.AddRevision(keys[i], Revision(n+rev+1), false)
 	}
 	if tree.Len() != n {
 		t.Fatalf("Len = %d, want %d", tree.Len(), n)
@@ -198,7 +198,7 @@ func TestBPTree_ManyKeys(t *testing.T) {
 func BenchmarkAddRevision(b *testing.B) {
 	var tree BPTree
 	for i := 0; i < b.N; i++ {
-		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1))
+		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1), false)
 	}
 }
 
@@ -206,7 +206,7 @@ func BenchmarkGetLatestRevisionByKey(b *testing.B) {
 	var tree BPTree
 	const n = 200_000
 	for i := 0; i < n; i++ {
-		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1))
+		tree.AddRevision([]byte(fmt.Sprintf("/registry/minions/node-%08d", i)), Revision(i+1), false)
 	}
 	keys := make([][]byte, 1024)
 	for i := range keys {
@@ -237,15 +237,15 @@ func shuffled(s []string, seed int64) []string {
 // latest revision is a delete below it.
 func TestCompact(t *testing.T) {
 	var tree BPTree
-	tree.AddRevision([]byte("a"), 1)
-	tree.AddRevision([]byte("a"), 5)
-	tree.AddRevision([]byte("a"), 9)
-	tree.AddRevision([]byte("b"), 2)
-	tree.AddTombstone([]byte("b"), 6)
-	tree.AddRevision([]byte("c"), 3)
-	tree.AddTombstone([]byte("c"), 12)
-	tree.AddRevision([]byte("d"), 4)
-	tree.AddRevision([]byte("d"), 11)
+	tree.AddRevision([]byte("a"), 1, false)
+	tree.AddRevision([]byte("a"), 5, false)
+	tree.AddRevision([]byte("a"), 9, false)
+	tree.AddRevision([]byte("b"), 2, false)
+	tree.AddRevision([]byte("b"), 6, true)
+	tree.AddRevision([]byte("c"), 3, false)
+	tree.AddRevision([]byte("c"), 12, true)
+	tree.AddRevision([]byte("d"), 4, false)
+	tree.AddRevision([]byte("d"), 11, false)
 
 	removed, dropped := tree.Compact(8)
 	// b is gone (2 revisions); a drops 1; c and d keep their latest below 8.

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -25,12 +25,13 @@
 // files, the archive is downloaded first.
 //
 // Compaction rewrites closed files keeping only the records that are still
-// live (the latest put of each key), so a compacted file is sparse in
-// revision: every record carries its revision, and a compacted file's name
-// carries the revision range it covers.
+// live (the latest write of each key as of the compaction point), so a
+// compacted file is sparse in revision: every record carries its revision,
+// and a compacted file's name carries the revision range it covers.
 package filesystemlog
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -44,7 +45,6 @@ import (
 	"sync"
 	"time"
 
-	"go.etcd.io/etcd/api/v3/mvccpb"
 	"k8s.io/klog/v2"
 
 	"justinsb.com/cloudetcd/pkg/persistence"
@@ -57,6 +57,10 @@ type Revision = persistence.Revision
 type LogRecord = persistence.LogRecord
 type LogListener = persistence.LogListener
 type TxnMeta = persistence.TxnMeta
+
+// liveFunc is the callback of persistence.Log.Compact: whether the record at
+// revision is still live for key.
+type liveFunc = func(key []byte, revision Revision) bool
 
 // Archive is an object store that closed log files are copied to, and
 // restored from on a machine that has none.
@@ -101,39 +105,89 @@ const (
 	// unmapAfter is how long a mapping of a file removed by compaction is
 	// kept before it is unmapped: records decoded from it alias its bytes,
 	// and a reader may still be using one.
+	//
+	// TODO: a grace period is a guess. Give each request a view that pins
+	// the files it reads, and unmap a retired file when its last view
+	// closes; that also makes long-running requests visible.
 	unmapAfter = time.Minute
 )
 
-// logFile is one file of the log. All but the last are closed.
-type logFile struct {
-	name string
+// fileInfo is what a log file's name says about it: the revisions it
+// covers, and whether it holds every one of them.
+type fileInfo struct {
 	// first and last bound the revisions the file covers. A dense file (one
-	// the log appended to) holds every revision in [first, last]; a
-	// compacted file holds only the live ones.
+	// the log appended to) holds every revision in [first, last]; a sparse
+	// file (one compaction wrote) holds only the live ones. A dense file's
+	// name gives only first; last is set from its record count.
 	first, last Revision
 	sparse      bool
-	// revisions lists a sparse file's records' revisions, parallel to its
-	// spans; nil for dense files, whose record i has revision first+i.
-	revisions []Revision
-	count     int
-	// size is the file's length in bytes, header included.
-	size int64
+}
+
+// filename is the file's name: its first revision, or for a sparse file
+// its range, in hex so that names sort in revision order.
+func (fi fileInfo) filename() string {
+	if fi.sparse {
+		return fmt.Sprintf("%016x-%016x.log", uint64(fi.first), uint64(fi.last))
+	}
+	return fmt.Sprintf("%016x.log", uint64(fi.first))
+}
+
+// parseFilename is the inverse of filename. A dense file's last is 0.
+func parseFilename(filename string) (fileInfo, error) {
+	if !strings.HasSuffix(filename, ".log") {
+		return fileInfo{}, fmt.Errorf("invalid filename format: %s", filename)
+	}
+	base := strings.TrimSuffix(filename, ".log")
+	parts := strings.SplitN(base, "-", 2)
+	first, err := strconv.ParseUint(parts[0], 16, 64)
+	if err != nil {
+		return fileInfo{}, fmt.Errorf("invalid filename format: %s", filename)
+	}
+	if len(parts) == 1 {
+		return fileInfo{first: Revision(first)}, nil
+	}
+	last, err := strconv.ParseUint(parts[1], 16, 64)
+	if err != nil || last < first {
+		return fileInfo{}, fmt.Errorf("invalid filename format: %s", filename)
+	}
+	return fileInfo{first: Revision(first), last: Revision(last), sparse: true}, nil
+}
+
+// logFile is one file of the log. All but the last are closed.
+type logFile struct {
+	fileInfo
+	name string
+	// count is the number of records in the file; size its length in bytes,
+	// header included.
+	count int
+	size  int64
 	// opened is when the file was created, for age-based rotation.
 	opened time.Time
 	// archived is whether the archive holds this (closed) file.
 	archived bool
+
+	// mu guards the state below, which is built as the file is written or
+	// read.
+	mu sync.Mutex
+	// spans locates each record in the file, and revisions gives each
+	// record's revision (nil for a dense file, whose record i has revision
+	// first+i). The active file's are extended as it is appended to; a
+	// closed file's are built on first read, when indexed becomes true.
+	indexed   bool
+	spans     []logcodec.Span
+	revisions []Revision
 	// mapped is the read-only memory mapping of a closed file, made on first
 	// read; records read from it alias its bytes (see
-	// logcodec.DecodeMessageAlias), so old records live in the page cache
-	// rather than on the heap.
+	// logcodec.EncodedRecord.DecodeAlias), so old records live in the page
+	// cache rather than on the heap. nil where the platform cannot map.
 	mapped []byte
-	// reader is the file opened for positioned reads (the active file, or
-	// any file where mapping is unavailable) and for mapping, opened on
-	// first use and kept.
+	// reader is the file opened for reading, on first use, and kept: it
+	// serves positioned reads of the active file (or of any file where
+	// mapping is unavailable) and is what a closed file is mapped from.
 	reader *os.File
 }
 
-// archiveOp is work for the uploader: copy a closed file to the archive, or
+// archiveOp is work for the archiver: copy a closed file to the archive, or
 // remove one that compaction superseded.
 type archiveOp struct {
 	name   string
@@ -141,6 +195,9 @@ type archiveOp struct {
 }
 
 // FilesystemLog is the log; see the package comment.
+//
+// Locks, in the order they are taken: writeMu, then mu, then a file's mu.
+// compactMu is taken first by Compact and never inside another.
 type FilesystemLog struct {
 	dir  string
 	opts Options
@@ -158,30 +215,21 @@ type FilesystemLog struct {
 	files        []*logFile
 	lastRevision Revision
 	listener     LogListener
-
-	// spans locates each record within its file, keyed by the file's first
-	// revision. Maintained for the active file as records are appended;
-	// rebuilt on first use for closed files.
-	spansMu sync.Mutex
-	spans   map[Revision][]logcodec.Span
-
-	// cache holds recently written records (reads of the active file).
-	cache *recordcache.Cache
-
-	// mapMu serializes creating mappings and guards retired.
-	mapMu sync.Mutex
 	// retired holds mappings of files removed by compaction until it is
 	// safe to unmap them.
 	retired []retiredMapping
 
+	// cache holds recently written records (reads of the active file).
+	cache *recordcache.Cache
+
 	// compactMu serializes compactions.
 	compactMu sync.Mutex
 
-	// archiveOps carries work to the uploader goroutine.
-	archiveOps   chan archiveOp
-	uploaderDone chan struct{}
-	stop         chan struct{}
-	rotatorDone  chan struct{}
+	// archiver copies closed files to the archive and removes superseded
+	// ones, in the background.
+	archiver *worker[archiveOp]
+	// rotator rotates the active file by age and unmaps retired mappings.
+	rotator *ticker
 
 	removeOnClose bool
 }
@@ -231,24 +279,19 @@ func NewFilesystemLogWithOptions(dir string, opts Options) (*FilesystemLog, erro
 	}
 
 	l := &FilesystemLog{
-		dir:          dir,
-		opts:         opts,
-		spans:        map[Revision][]logcodec.Span{},
-		cache:        recordcache.New(opts.CacheBytes),
-		archiveOps:   make(chan archiveOp, 4096),
-		uploaderDone: make(chan struct{}),
-		stop:         make(chan struct{}),
-		rotatorDone:  make(chan struct{}),
+		dir:      dir,
+		opts:     opts,
+		cache:    recordcache.New(opts.CacheBytes),
+		archiver: newWorker[archiveOp](4096),
 	}
 
-	ctx := context.Background()
-	if err := l.open(ctx); err != nil {
+	if err := l.open(context.Background()); err != nil {
 		return nil, err
 	}
 
 	l.batching = batch.NewBatching(l.lastRevision, l.commitBatch)
-	go l.uploader(ctx)
-	go l.rotator()
+	l.archiver.start(l.archive)
+	l.rotator = startTicker(time.Second, l.tick)
 	return l, nil
 }
 
@@ -296,7 +339,6 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 					return fmt.Errorf("log file %s: record %d has revision %d, outside or out of order for %d-%d; recovery needed", f.name, j, r, f.first, f.last)
 				}
 			}
-			f.revisions = revisions
 		} else {
 			for j, r := range revisions {
 				if r != f.first+Revision(j) {
@@ -314,7 +356,10 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 			return fmt.Errorf("log starts at revision %d, not 1; recovery needed", f.first)
 		}
 		if i == len(files)-1 && !f.sparse {
-			l.spans[f.first] = spans
+			// The active file's index is kept from the start; a closed
+			// file's is rebuilt on first read.
+			f.spans = spans
+			f.indexed = true
 		}
 	}
 
@@ -330,7 +375,7 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 	if l.opts.Archive != nil {
 		for _, f := range files[:len(files)-1] {
 			if !f.archived {
-				l.archiveOps <- archiveOp{name: f.name}
+				l.archiver.add(archiveOp{name: f.name})
 			}
 		}
 	}
@@ -339,7 +384,7 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 		// An archived file is never appended to again (its object would no
 		// longer match), nor is a compacted one; start the next file.
 		if !last.archived && l.opts.Archive != nil {
-			l.archiveOps <- archiveOp{name: last.name}
+			l.archiver.add(archiveOp{name: last.name})
 		}
 		return l.newActiveFile()
 	}
@@ -364,12 +409,12 @@ func (l *FilesystemLog) listFiles() ([]*logFile, error) {
 		if e.IsDir() {
 			continue
 		}
-		first, last, sparse, err := parseFilename(e.Name())
+		info, err := parseFilename(e.Name())
 		if err != nil {
 			klog.Warningf("ignoring file with unexpected name %q: %v", e.Name(), err)
 			continue
 		}
-		files = append(files, &logFile{name: e.Name(), first: first, last: last, sparse: sparse})
+		files = append(files, &logFile{fileInfo: info, name: e.Name()})
 	}
 	slices.SortFunc(files, func(a, b *logFile) int {
 		if a.first != b.first {
@@ -388,6 +433,13 @@ func (l *FilesystemLog) listFiles() ([]*logFile, error) {
 	var kept []*logFile
 	for _, f := range files {
 		if n := len(kept); n > 0 && kept[n-1].sparse && f.first >= kept[n-1].first && f.first <= kept[n-1].last {
+			// Removing data is permanent, so to be clear about why this is
+			// safe: the compacted file was synced and renamed into place
+			// before compaction started removing the files it replaced, and
+			// it covers this file's revisions, so this file is one that
+			// compaction was about to remove when it was interrupted.
+			// Keeping it would gain nothing: even if we archived it, the
+			// next compaction would delete it again.
 			klog.Infof("removing log file %s, superseded by compacted %s", f.name, kept[n-1].name)
 			if err := os.Remove(filepath.Join(l.dir, f.name)); err != nil {
 				return nil, fmt.Errorf("removing superseded log file %s: %w", f.name, err)
@@ -431,10 +483,10 @@ func (l *FilesystemLog) reconcileArchive(ctx context.Context, files []*logFile) 
 			f.archived = true
 			continue
 		}
-		first, _, _, err := parseFilename(name)
-		if err == nil && l.superseded(files, first) {
+		info, err := parseFilename(name)
+		if err == nil && l.superseded(files, info.first) {
 			// Compaction replaced it locally but had not yet removed it.
-			l.archiveOps <- archiveOp{name: name, remove: true}
+			l.archiver.add(archiveOp{name: name, remove: true})
 			continue
 		}
 		return nil, fmt.Errorf("archive holds %s, which this log does not have; is another instance writing to the archive?", name)
@@ -455,8 +507,8 @@ func (l *FilesystemLog) superseded(files []*logFile, first Revision) bool {
 // newActiveFile starts the file for revision lastRevision+1. Called with
 // writeMu and mu held (or before the log is shared).
 func (l *FilesystemLog) newActiveFile() error {
-	first := l.lastRevision + 1
-	name := revisionToFilename(first)
+	info := fileInfo{first: l.lastRevision + 1, last: l.lastRevision}
+	name := info.filename()
 	f, err := os.OpenFile(filepath.Join(l.dir, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return fmt.Errorf("creating log file %s: %w", name, err)
@@ -474,10 +526,7 @@ func (l *FilesystemLog) newActiveFile() error {
 		f.Close()
 		return err
 	}
-	l.files = append(l.files, &logFile{name: name, first: first, last: first - 1, size: int64(len(header)), opened: time.Now()})
-	l.spansMu.Lock()
-	l.spans[first] = nil
-	l.spansMu.Unlock()
+	l.files = append(l.files, &logFile{fileInfo: info, name: name, size: int64(len(header)), opened: time.Now(), indexed: true})
 	l.active = f
 	return nil
 }
@@ -522,9 +571,9 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 	for i := range spans {
 		spans[i].Offset += base
 	}
-	l.spansMu.Lock()
-	l.spans[active.first] = append(l.spans[active.first], spans...)
-	l.spansMu.Unlock()
+	active.mu.Lock()
+	active.spans = append(active.spans, spans...)
+	active.mu.Unlock()
 	startRevision := l.lastRevision + 1
 	for i, r := range records {
 		l.cache.Put(startRevision+Revision(i), r)
@@ -548,7 +597,7 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 
 // rotateLocked closes the active file and starts the next one. Called with
 // writeMu and mu held. The next file is created before the old one is handed
-// to the uploader, so the last file in the directory is always the active
+// to the archiver, so the last file in the directory is always the active
 // one and a closed file is never appended to again.
 func (l *FilesystemLog) rotateLocked() error {
 	old := l.files[len(l.files)-1]
@@ -563,74 +612,59 @@ func (l *FilesystemLog) rotateLocked() error {
 	}
 	klog.V(2).Infof("rotated log file %s (%d records, %d bytes)", old.name, old.count, old.size)
 	if l.opts.Archive != nil {
-		l.archiveOps <- archiveOp{name: old.name}
+		l.archiver.add(archiveOp{name: old.name})
 	}
 	return nil
 }
 
-// rotator rotates the active file by age, and unmaps retired mappings.
-func (l *FilesystemLog) rotator() {
-	defer close(l.rotatorDone)
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-l.stop:
-			return
-		case <-ticker.C:
+// tick rotates the active file once it is RotateAfter old, and unmaps
+// mappings that have been retired for long enough.
+func (l *FilesystemLog) tick() {
+	l.writeMu.Lock()
+	defer l.writeMu.Unlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	active := l.files[len(l.files)-1]
+	if active.count > 0 && time.Since(active.opened) >= l.opts.RotateAfter {
+		if err := l.rotateLocked(); err != nil {
+			klog.Errorf("rotating log file: %v", err)
 		}
-		l.writeMu.Lock()
-		l.mu.Lock()
-		active := l.files[len(l.files)-1]
-		if active.count > 0 && time.Since(active.opened) >= l.opts.RotateAfter {
-			if err := l.rotateLocked(); err != nil {
-				klog.Errorf("rotating log file: %v", err)
-			}
-		}
-		l.mu.Unlock()
-		l.writeMu.Unlock()
-		l.unmapRetired(false)
 	}
+	l.unmapRetiredLocked(false)
 }
 
-// uploader copies closed files to the archive and removes superseded ones,
-// retrying until each succeeds. A conflict means another writer is using
-// the archive, which is fatal.
-func (l *FilesystemLog) uploader(ctx context.Context) {
-	defer close(l.uploaderDone)
-	if l.opts.Archive == nil {
-		return
-	}
-	for op := range l.archiveOps {
-		backoff := time.Second
-		for {
-			var err error
-			if op.remove {
-				err = l.opts.Archive.Delete(ctx, op.name)
-			} else {
-				err = l.opts.Archive.Upload(ctx, op.name, filepath.Join(l.dir, op.name))
-			}
-			if err == nil {
-				if !op.remove {
-					klog.V(2).Infof("archived log file %s", op.name)
-					l.mu.Lock()
-					for _, f := range l.files {
-						if f.name == op.name {
-							f.archived = true
-						}
+// archive carries out one archive operation, retrying until it succeeds. A
+// conflict means another writer is using the archive, which is fatal.
+func (l *FilesystemLog) archive(op archiveOp) {
+	ctx := context.Background()
+	backoff := time.Second
+	for {
+		var err error
+		if op.remove {
+			err = l.opts.Archive.Delete(ctx, op.name)
+		} else {
+			err = l.opts.Archive.Upload(ctx, op.name, filepath.Join(l.dir, op.name))
+		}
+		if err == nil {
+			if !op.remove {
+				klog.V(2).Infof("archived log file %s", op.name)
+				l.mu.Lock()
+				for _, f := range l.files {
+					if f.name == op.name {
+						f.archived = true
 					}
-					l.mu.Unlock()
 				}
-				break
+				l.mu.Unlock()
 			}
-			if errors.Is(err, persistence.ErrRevisionConflict) {
-				panic(fmt.Sprintf("archiving log file %s: %v", op.name, err))
-			}
-			klog.Errorf("archive operation on %s (retrying in %s): %v", op.name, backoff, err)
-			time.Sleep(backoff)
-			if backoff < 30*time.Second {
-				backoff *= 2
-			}
+			return
+		}
+		if errors.Is(err, persistence.ErrRevisionConflict) {
+			panic(fmt.Sprintf("archiving log file %s: %v", op.name, err))
+		}
+		klog.Errorf("archive operation on %s (retrying in %s): %v", op.name, backoff, err)
+		time.Sleep(backoff)
+		if backoff < 30*time.Second {
+			backoff *= 2
 		}
 	}
 }
@@ -655,13 +689,13 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 		// Decode in place, aliasing the key and value bytes rather than
 		// copying them. Not cached: the cache is for the write-recent set,
 		// and a cached alias would pin the mapping past compaction.
-		record, err := logcodec.DecodeMessageAlias(m)
+		record, err := m.DecodeAlias()
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode log record %d: %w", revision, err)
 		}
 		return record, nil
 	}
-	record, err := logcodec.DecodeMessage(m)
+	record, err := m.Decode()
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode log record %d: %w", revision, err)
 	}
@@ -673,7 +707,7 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 // file they alias its memory mapping (aliased is true) and must not be
 // retained; for the active file, or where mapping is unavailable, they are
 // one positioned read into a fresh buffer.
-func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, err error) {
+func (l *FilesystemLog) recordBytes(revision Revision) (m logcodec.EncodedRecord, aliased bool, err error) {
 	l.mu.RLock()
 	f, ok := l.findFile(revision)
 	active := ok && f == l.files[len(l.files)-1]
@@ -682,35 +716,26 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 		return nil, false, fmt.Errorf("log entry for revision %d not found in any file", revision)
 	}
 
+	f.mu.Lock()
 	if !active {
-		m, err := l.mapping(f)
-		if err != nil {
+		if err := l.loadLocked(f); err != nil {
+			f.mu.Unlock()
 			return nil, false, err
 		}
-		if m != nil {
-			spans, err := l.fileSpansFrom(f, m)
-			if err != nil {
-				return nil, false, err
-			}
-			pos, err := f.position(revision, len(spans))
-			if err != nil {
-				return nil, false, err
-			}
-			span := spans[pos]
-			return m[span.Offset : span.Offset+span.Length], true, nil
-		}
 	}
-
-	spans, err := l.fileSpans(f)
+	pos, err := f.position(revision)
 	if err != nil {
+		f.mu.Unlock()
 		return nil, false, err
 	}
-	pos, err := f.position(revision, len(spans))
-	if err != nil {
-		return nil, false, err
+	span := f.spans[pos]
+	if f.mapped != nil {
+		mapped := f.mapped
+		f.mu.Unlock()
+		return span.Bytes(mapped), true, nil
 	}
-	span := spans[pos]
-	file, err := l.reader(f)
+	file, err := l.readerLocked(f)
+	f.mu.Unlock()
 	if err != nil {
 		return nil, false, err
 	}
@@ -721,56 +746,47 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 	return buf, false, nil
 }
 
-// position returns the index of revision's record in the file, or
-// ErrCompacted if the file is sparse and compaction dropped it.
-func (f *logFile) position(revision Revision, count int) (int, error) {
-	if !f.sparse {
-		pos := int(revision - f.first)
-		if pos < 0 || pos >= count {
-			return 0, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, count)
-		}
-		return pos, nil
+// loadLocked prepares a closed file for reading: maps it, where the platform
+// can, and indexes its records. Both happen once. A mapping that fails where
+// it should work is fatal: the alternative would be a positioned read per
+// record, a large and silent change in how the server performs. Called with
+// f.mu held.
+func (l *FilesystemLog) loadLocked(f *logFile) error {
+	file, err := l.readerLocked(f)
+	if err != nil {
+		return err
 	}
-	pos := sort.Search(len(f.revisions), func(i int) bool { return f.revisions[i] >= revision })
-	if pos >= len(f.revisions) || f.revisions[pos] != revision {
-		return 0, fmt.Errorf("revision %d: %w", revision, persistence.ErrCompacted)
-	}
-	return pos, nil
-}
-
-// mapping returns a closed file's memory mapping, creating it on first use
-// from the file's read handle, or nil where the platform has no memory
-// mapping. A mapping that fails where it should work is fatal: the
-// alternative would be a positioned read per record, a large and silent
-// change in how the server performs.
-func (l *FilesystemLog) mapping(f *logFile) ([]byte, error) {
-	l.mapMu.Lock()
-	defer l.mapMu.Unlock()
 	if f.mapped == nil {
-		file, err := l.readerLocked(f)
-		if err != nil {
-			return nil, err
-		}
 		m, err := mmapFile(file, f.size)
-		if errors.Is(err, errNoMmap) {
-			return nil, nil
-		}
-		if err != nil {
+		if err != nil && !errors.Is(err, errNoMmap) {
 			panic(fmt.Sprintf("memory-mapping log file %s (%d bytes): %v", f.name, f.size, err))
 		}
 		f.mapped = m
 	}
-	return f.mapped, nil
+	if f.indexed {
+		return nil
+	}
+	data := f.mapped
+	if data == nil {
+		data = make([]byte, f.size)
+		if _, err := io.ReadFull(io.NewSectionReader(file, 0, f.size), data); err != nil {
+			return fmt.Errorf("failed to read log file %s: %w", f.name, err)
+		}
+	}
+	spans, revisions, err := logcodec.Offsets(data)
+	if err != nil {
+		return fmt.Errorf("indexing log file %s: %w", f.name, err)
+	}
+	f.spans = spans
+	if f.sparse {
+		f.revisions = revisions
+	}
+	f.indexed = true
+	return nil
 }
 
-// reader returns a file's handle for positioned reads, opening it on first
-// use and keeping it open.
-func (l *FilesystemLog) reader(f *logFile) (*os.File, error) {
-	l.mapMu.Lock()
-	defer l.mapMu.Unlock()
-	return l.readerLocked(f)
-}
-
+// readerLocked returns the file's read handle, opening it on first use.
+// Called with f.mu held.
 func (l *FilesystemLog) readerLocked(f *logFile) (*os.File, error) {
 	if f.reader == nil {
 		file, err := os.Open(filepath.Join(l.dir, f.name))
@@ -782,38 +798,31 @@ func (l *FilesystemLog) readerLocked(f *logFile) (*os.File, error) {
 	return f.reader, nil
 }
 
-// fileSpans returns the record spans of a file, scanning its length
-// prefixes on first use for closed files.
-func (l *FilesystemLog) fileSpans(f *logFile) ([]logcodec.Span, error) {
-	l.spansMu.Lock()
-	spans, ok := l.spans[f.first]
-	l.spansMu.Unlock()
-	if ok {
-		return spans, nil
+// position returns the index of revision's record in the file. For a sparse
+// file, a revision that compaction dropped is ErrCompacted. Called with f.mu
+// held and the file indexed.
+func (f *logFile) position(revision Revision) (int, error) {
+	if !f.sparse {
+		pos := int(revision - f.first)
+		if pos < 0 || pos >= len(f.spans) {
+			return 0, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(f.spans))
+		}
+		return pos, nil
 	}
-	data, err := os.ReadFile(filepath.Join(l.dir, f.name))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read log file %s: %w", f.name, err)
+	pos := sort.Search(len(f.revisions), func(i int) bool { return f.revisions[i] >= revision })
+	if pos >= len(f.revisions) || f.revisions[pos] != revision {
+		return 0, fmt.Errorf("revision %d: %w", revision, persistence.ErrCompacted)
 	}
-	return l.fileSpansFrom(f, data)
+	return pos, nil
 }
 
-// fileSpansFrom is fileSpans for a file whose bytes are already at hand.
-func (l *FilesystemLog) fileSpansFrom(f *logFile, data []byte) ([]logcodec.Span, error) {
-	l.spansMu.Lock()
-	spans, ok := l.spans[f.first]
-	l.spansMu.Unlock()
-	if ok {
-		return spans, nil
+// revisionAt returns the revision of the file's record i. The file must be
+// indexed.
+func (f *logFile) revisionAt(i int) Revision {
+	if f.revisions != nil {
+		return f.revisions[i]
 	}
-	spans, _, err := logcodec.Offsets(data)
-	if err != nil {
-		return nil, fmt.Errorf("indexing log file %s: %w", f.name, err)
-	}
-	l.spansMu.Lock()
-	l.spans[f.first] = spans
-	l.spansMu.Unlock()
-	return spans, nil
+	return f.first + Revision(i)
 }
 
 // findFile finds the file covering revision. Called with mu held.
@@ -861,7 +870,7 @@ func (l *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 			if revisions[j] < fromRevision {
 				continue
 			}
-			record, err := logcodec.DecodeMessage(data[span.Offset : span.Offset+span.Length])
+			record, err := span.Bytes(data).Decode()
 			if err != nil {
 				return fmt.Errorf("failed to decode log record %d from file %s: %w", revisions[j], f.name, err)
 			}
@@ -873,13 +882,15 @@ func (l *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 	return nil
 }
 
-// Compact rewrites the closed files at or below through, keeping only their
-// live records: puts that live(key, revision) confirms are still the latest
-// for their key. Deletes and superseded puts are dropped. Files are merged
-// while the result stays under RotateBytes; a compacted file that is still
-// mostly live is left alone. The originals are removed (from the archive
-// too) once the replacement is durable.
-func (l *FilesystemLog) Compact(ctx context.Context, through Revision, live func(key []byte, revision Revision) bool) error {
+// Compact rewrites the closed files at or below through so that they hold
+// only their live records. A record is live if live(key, revision) says so
+// for a key it touches; the index decides what that means (see
+// memorystorage.Compact: the key's latest put or delete at or below
+// through). Compact merges neighbouring files while their live bytes fit in
+// RotateBytes, leaves a lone file alone while fewer than a tenth of its
+// records are dead, and removes each replaced file, locally and from the
+// archive, once its replacement is durable.
+func (l *FilesystemLog) Compact(ctx context.Context, through Revision, live liveFunc) error {
 	l.compactMu.Lock()
 	defer l.compactMu.Unlock()
 
@@ -891,106 +902,137 @@ func (l *FilesystemLog) Compact(ctx context.Context, through Revision, live func
 		}
 	}
 	l.mu.RUnlock()
+	if len(eligible) == 0 {
+		return nil
+	}
 
-	// Group consecutive files by their live bytes so that each output stays
-	// under RotateBytes: a dense file that is mostly dead merges with its
-	// neighbours; a mostly live one stays on its own.
+	// Measure each file first, then walk them in order.
+	type measured struct {
+		f         *logFile
+		liveBytes int64
+		dead      int
+	}
+	var files []measured
+	for _, f := range eligible {
+		var liveBytes int64
+		dead, err := l.liveRecords(f, live, func(m logcodec.EncodedRecord, rev Revision) error {
+			liveBytes += int64(len(m)) + 4
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		files = append(files, measured{f: f, liveBytes: liveBytes, dead: dead})
+	}
+
 	var group []*logFile
 	var groupBytes int64
+	var groupDead int
 	flush := func() error {
 		if len(group) == 0 {
 			return nil
 		}
-		err := l.compactGroup(ctx, group, live)
-		group, groupBytes = nil, 0
-		return err
-	}
-	for _, f := range eligible {
-		var liveBytes int64
-		if _, err := l.liveRecords(f, live, func(m []byte, rev Revision) { liveBytes += int64(len(m)) + 4 }); err != nil {
-			return err
+		defer func() { group, groupBytes, groupDead = nil, 0, 0 }()
+		if len(group) == 1 && (groupDead == 0 || groupDead*10 < group[0].count) {
+			// Rewriting a lone file that is still (nearly) all live would
+			// gain nothing. It stays as it is, and is measured again next
+			// time.
+			return nil
 		}
-		if groupBytes > 0 && groupBytes+liveBytes > l.opts.RotateBytes {
+		return l.compactGroup(ctx, group, live)
+	}
+	for _, m := range files {
+		if groupBytes > 0 && groupBytes+m.liveBytes > l.opts.RotateBytes {
 			if err := flush(); err != nil {
 				return err
 			}
 		}
-		group = append(group, f)
-		groupBytes += liveBytes
+		group = append(group, m.f)
+		groupBytes += m.liveBytes
+		groupDead += m.dead
 	}
 	return flush()
 }
 
-// compactGroup replaces a run of consecutive closed files with one file
+// compactGroup replaces a run of neighbouring closed files with one file
 // holding their live records.
-func (l *FilesystemLog) compactGroup(ctx context.Context, group []*logFile, live func(key []byte, revision Revision) bool) error {
-	first, last := group[0].first, group[len(group)-1].last
-	name := rangeToFilename(first, last)
-	if len(group) == 1 && group[0].name == name {
-		// Already compacted into this exact file; see whether it has rotted.
-		if dead, err := l.liveRecords(group[0], live, nil); err != nil {
-			return err
-		} else if dead*10 < group[0].count {
-			return nil
-		}
-	}
+func (l *FilesystemLog) compactGroup(ctx context.Context, group []*logFile, live liveFunc) error {
+	info := fileInfo{first: group[0].first, last: group[len(group)-1].last, sparse: true}
+	name := info.filename()
 
-	buf := append([]byte(nil), logcodec.Header()...)
-	var revisions []Revision
-	var spans []logcodec.Span
-	var kept int
-	for _, f := range group {
-		if _, err := l.liveRecords(f, live, func(m []byte, rev Revision) {
-			var span logcodec.Span
-			buf, span = logcodec.AppendRaw(buf, m)
-			spans = append(spans, span)
-			revisions = append(revisions, rev)
-			kept++
-		}); err != nil {
-			return err
-		}
-	}
-
+	// Stream the live records to a temporary file and rename it into place,
+	// so that a crash leaves either the originals alone or the originals
+	// beside a complete replacement (which listFiles resolves).
 	tmp := filepath.Join(l.dir, name+".tmp")
-	if err := os.WriteFile(tmp, buf, 0644); err != nil {
-		return fmt.Errorf("writing compacted log file %s: %w", name, err)
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("creating compacted log file %s: %w", name, err)
 	}
-	if err := syncFile(tmp); err != nil {
+	fail := func(err error) error {
+		out.Close()
+		os.Remove(tmp)
 		return err
 	}
+	w := bufio.NewWriterSize(out, 1<<20)
+	var size int64
+	var spans []logcodec.Span
+	var revisions []Revision
+	n, err := w.Write(logcodec.Header())
+	if err != nil {
+		return fail(fmt.Errorf("writing compacted log file %s: %w", name, err))
+	}
+	size += int64(n)
+	for _, f := range group {
+		if _, err := l.liveRecords(f, live, func(m logcodec.EncodedRecord, rev Revision) error {
+			n, err := logcodec.WriteRecord(w, m)
+			if err != nil {
+				return fmt.Errorf("writing compacted log file %s: %w", name, err)
+			}
+			spans = append(spans, logcodec.Span{Offset: int(size) + n - len(m), Length: len(m)})
+			revisions = append(revisions, rev)
+			size += int64(n)
+			return nil
+		}); err != nil {
+			return fail(err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return fail(fmt.Errorf("writing compacted log file %s: %w", name, err))
+	}
+	if err := out.Sync(); err != nil {
+		return fail(fmt.Errorf("syncing compacted log file %s: %w", name, err))
+	}
+	if err := out.Close(); err != nil {
+		return fail(fmt.Errorf("closing compacted log file %s: %w", name, err))
+	}
 	if err := os.Rename(tmp, filepath.Join(l.dir, name)); err != nil {
-		return fmt.Errorf("renaming compacted log file %s: %w", name, err)
+		return fail(fmt.Errorf("renaming compacted log file %s: %w", name, err))
 	}
 	if err := syncDir(l.dir); err != nil {
 		return err
 	}
-	compacted := &logFile{name: name, first: first, last: last, sparse: true, revisions: revisions, count: kept, size: int64(len(buf)), opened: time.Now(), archived: false}
+	compacted := &logFile{fileInfo: info, name: name, count: len(spans), size: size, opened: time.Now(), indexed: true, spans: spans, revisions: revisions}
 
-	// Swap it into the index, retire the originals' mappings, and remove
-	// the originals.
+	// Swap it into the index and retire the originals: their mappings are
+	// kept for a while (a reader may hold a record decoded from one), their
+	// read handles closed (a replaced-in-place file's handle is the old
+	// inode), and their files removed.
 	l.mu.Lock()
 	i := slices.Index(l.files, group[0])
 	l.files = slices.Replace(l.files, i, i+len(group), compacted)
-	l.spansMu.Lock()
 	for _, f := range group {
-		delete(l.spans, f.first)
-	}
-	l.spans[first] = spans
-	l.spansMu.Unlock()
-	l.mu.Unlock()
-
-	l.mapMu.Lock()
-	for _, f := range group {
+		f.mu.Lock()
 		if f.mapped != nil {
 			l.retired = append(l.retired, retiredMapping{mapped: f.mapped, at: time.Now()})
 			f.mapped = nil
 		}
-		if f.reader != nil && f.name != name {
+		if f.reader != nil {
 			f.reader.Close()
 			f.reader = nil
 		}
+		f.mu.Unlock()
 	}
-	l.mapMu.Unlock()
+	l.mu.Unlock()
 
 	var oldBytes int64
 	for _, f := range group {
@@ -1003,66 +1045,68 @@ func (l *FilesystemLog) compactGroup(ctx context.Context, group []*logFile, live
 		}
 	}
 	klog.V(1).Infof("compacted %d file(s) covering revisions %d-%d into %s: %d records kept, %d MB -> %d MB",
-		len(group), first, last, name, kept, oldBytes>>20, compacted.size>>20)
+		len(group), info.first, info.last, name, len(spans), oldBytes>>20, size>>20)
 
 	if l.opts.Archive != nil {
-		l.archiveOps <- archiveOp{name: name}
+		l.archiver.add(archiveOp{name: name})
 		for _, f := range group {
 			if f.name != name {
-				l.archiveOps <- archiveOp{name: f.name, remove: true}
+				l.archiver.add(archiveOp{name: f.name, remove: true})
 			}
 		}
 	}
 	return nil
 }
 
-// liveRecords scans a closed file, calling keep for each live record with
-// its raw bytes and revision, and returns the number of records dropped. A
-// record is live if any of its puts is still the latest for its key;
-// deletes are never live.
-func (l *FilesystemLog) liveRecords(f *logFile, live func(key []byte, revision Revision) bool, keep func(m []byte, rev Revision)) (int, error) {
-	data, err := l.mapping(f)
-	if err != nil {
+// liveRecords calls keep with each live record of a closed file, in order,
+// and returns how many records were dead. A record is live if live says so
+// for any key it touches, whether by a put or a delete: a delete is live
+// while it is the key's latest write as of the compaction point, and the
+// index (which decided that) still refers to it.
+func (l *FilesystemLog) liveRecords(f *logFile, live liveFunc, keep func(m logcodec.EncodedRecord, rev Revision) error) (dead int, err error) {
+	f.mu.Lock()
+	if err := l.loadLocked(f); err != nil {
+		f.mu.Unlock()
 		return 0, err
 	}
+	data, spans, file := f.mapped, f.spans, f.reader
+	f.mu.Unlock()
 	if data == nil {
-		if data, err = os.ReadFile(filepath.Join(l.dir, f.name)); err != nil {
+		data = make([]byte, f.size)
+		if _, err := io.ReadFull(io.NewSectionReader(file, 0, f.size), data); err != nil {
 			return 0, fmt.Errorf("failed to read log file %s: %w", f.name, err)
 		}
 	}
-	spans, revisions, err := logcodec.Offsets(data)
-	if err != nil {
-		return 0, fmt.Errorf("indexing log file %s: %w", f.name, err)
-	}
-	dropped := 0
 	for i, span := range spans {
-		m := data[span.Offset : span.Offset+span.Length]
-		record, err := logcodec.DecodeMessageAlias(m)
+		m := span.Bytes(data)
+		rev := f.revisionAt(i)
+		record, err := m.DecodeAlias()
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode log record %d from file %s: %w", revisions[i], f.name, err)
+			return 0, fmt.Errorf("failed to decode log record %d from file %s: %w", rev, f.name, err)
 		}
 		isLive := false
 		for _, ev := range record.Events {
-			if ev.Type == mvccpb.PUT && live(ev.Kv.Key, revisions[i]) {
+			if live(ev.Kv.Key, rev) {
 				isLive = true
 				break
 			}
 		}
 		if !isLive {
-			dropped++
+			dead++
 			continue
 		}
 		if keep != nil {
-			keep(m, revisions[i])
+			if err := keep(m, rev); err != nil {
+				return 0, err
+			}
 		}
 	}
-	return dropped, nil
+	return dead, nil
 }
 
-// unmapRetired unmaps mappings retired long enough ago (or all of them).
-func (l *FilesystemLog) unmapRetired(all bool) {
-	l.mapMu.Lock()
-	defer l.mapMu.Unlock()
+// unmapRetiredLocked unmaps mappings retired long enough ago (or all of
+// them). Called with mu held.
+func (l *FilesystemLog) unmapRetiredLocked(all bool) {
 	kept := l.retired[:0]
 	for _, r := range l.retired {
 		if all || time.Since(r.at) >= unmapAfter {
@@ -1083,8 +1127,7 @@ func (l *FilesystemLog) Close() error {
 	if err := l.batching.Close(); err != nil {
 		errs = append(errs, err)
 	}
-	close(l.stop)
-	<-l.rotatorDone
+	l.rotator.stop()
 
 	l.writeMu.Lock()
 	l.mu.Lock()
@@ -1099,16 +1142,14 @@ func (l *FilesystemLog) Close() error {
 	l.mu.Unlock()
 	l.writeMu.Unlock()
 
-	close(l.archiveOps)
-	select {
-	case <-l.uploaderDone:
-	case <-time.After(30 * time.Second):
+	if !l.archiver.stop(30 * time.Second) {
 		klog.Warningf("log closed with archive operations still pending; they will resume on the next start")
 	}
 
-	l.unmapRetired(true)
-	l.mapMu.Lock()
+	l.mu.Lock()
+	l.unmapRetiredLocked(true)
 	for _, f := range l.files {
+		f.mu.Lock()
 		if err := munmapFile(f.mapped); err != nil {
 			errs = append(errs, err)
 		}
@@ -1119,8 +1160,9 @@ func (l *FilesystemLog) Close() error {
 			}
 			f.reader = nil
 		}
+		f.mu.Unlock()
 	}
-	l.mapMu.Unlock()
+	l.mu.Unlock()
 
 	if l.removeOnClose {
 		if err := os.RemoveAll(l.dir); err != nil {
@@ -1137,16 +1179,6 @@ func (l *FilesystemLog) SetListener(listener LogListener) {
 	l.listener = listener
 }
 
-// syncFile fsyncs a file.
-func syncFile(path string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return f.Sync()
-}
-
 // syncDir fsyncs a directory so that new directory entries are durable.
 func syncDir(dir string) error {
 	d, err := os.Open(dir)
@@ -1155,37 +1187,4 @@ func syncDir(dir string) error {
 	}
 	defer d.Close()
 	return d.Sync()
-}
-
-// revisionToFilename names a dense file by its first revision.
-func revisionToFilename(first Revision) string {
-	return fmt.Sprintf("%016x.log", uint64(first))
-}
-
-// rangeToFilename names a compacted file by the revision range it covers.
-func rangeToFilename(first, last Revision) string {
-	return fmt.Sprintf("%016x-%016x.log", uint64(first), uint64(last))
-}
-
-// parseFilename is the inverse of revisionToFilename and rangeToFilename.
-// A dense file's last revision is not in its name (it is derived from its
-// record count) and is returned as 0.
-func parseFilename(filename string) (first, last Revision, sparse bool, err error) {
-	if !strings.HasSuffix(filename, ".log") {
-		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
-	}
-	base := strings.TrimSuffix(filename, ".log")
-	parts := strings.SplitN(base, "-", 2)
-	f, err := strconv.ParseUint(parts[0], 16, 64)
-	if err != nil {
-		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
-	}
-	if len(parts) == 1 {
-		return Revision(f), 0, false, nil
-	}
-	l, err := strconv.ParseUint(parts[1], 16, 64)
-	if err != nil || l < f {
-		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
-	}
-	return Revision(f), Revision(l), true, nil
 }

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -20,9 +20,14 @@
 // closed file is uploaded to the Archive (if there is one) in the
 // background. Local files are the read store: the log keeps in memory only
 // its file index, each record's byte span within its file, and a bounded
-// cache of recently written or read records; anything else is a positioned
-// read of one record. On a machine with no local files, the archive is
-// downloaded first.
+// cache of recently written records; a closed file is memory-mapped on
+// first read and its records decoded in place. On a machine with no local
+// files, the archive is downloaded first.
+//
+// Compaction rewrites closed files keeping only the records that are still
+// live (the latest put of each key), so a compacted file is sparse in
+// revision: every record carries its revision, and a compacted file's name
+// carries the revision range it covers.
 package filesystemlog
 
 import (
@@ -33,11 +38,13 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	"k8s.io/klog/v2"
 
 	"justinsb.com/cloudetcd/pkg/persistence"
@@ -64,14 +71,18 @@ type Archive interface {
 	Upload(ctx context.Context, name string, path string) error
 	// Download copies the archived file name to path.
 	Download(ctx context.Context, name string, path string) error
+	// Delete removes an archived file (one superseded by compaction). A
+	// missing file is not an error.
+	Delete(ctx context.Context, name string) error
 }
 
 // Options configures a FilesystemLog.
 type Options struct {
-	// CacheBytes bounds the in-memory cache of decoded records; records not
-	// in it are read from disk on demand. <= 0 means unbounded.
+	// CacheBytes bounds the in-memory cache of recently written records;
+	// everything else is read from disk on demand. <= 0 means unbounded.
 	CacheBytes int64
-	// RotateBytes rotates the active file once it is this large.
+	// RotateBytes rotates the active file once it is this large; it is also
+	// the size compaction aims for when it merges files.
 	RotateBytes int64
 	// RotateAfter rotates the active file once it is this old and has any
 	// records. So a busy log rotates by size every few seconds and an idle
@@ -86,13 +97,25 @@ const (
 	DefaultCacheBytes  = 256 << 20
 	DefaultRotateBytes = 64 << 20
 	DefaultRotateAfter = 5 * time.Minute
+
+	// unmapAfter is how long a mapping of a file removed by compaction is
+	// kept before it is unmapped: records decoded from it alias its bytes,
+	// and a reader may still be using one.
+	unmapAfter = time.Minute
 )
 
 // logFile is one file of the log. All but the last are closed.
 type logFile struct {
-	name  string
-	first Revision
-	count int
+	name string
+	// first and last bound the revisions the file covers. A dense file (one
+	// the log appended to) holds every revision in [first, last]; a
+	// compacted file holds only the live ones.
+	first, last Revision
+	sparse      bool
+	// revisions lists a sparse file's records' revisions, parallel to its
+	// spans; nil for dense files, whose record i has revision first+i.
+	revisions []Revision
+	count     int
 	// size is the file's length in bytes, header included.
 	size int64
 	// opened is when the file was created, for age-based rotation.
@@ -105,11 +128,17 @@ type logFile struct {
 	// rather than on the heap.
 	mapped []byte
 	// reader is the file opened for positioned reads (the active file, or
-	// any file where mapping is unavailable), opened on first read and kept.
+	// any file where mapping is unavailable) and for mapping, opened on
+	// first use and kept.
 	reader *os.File
 }
 
-func (f *logFile) last() Revision { return f.first + Revision(f.count) - 1 }
+// archiveOp is work for the uploader: copy a closed file to the archive, or
+// remove one that compaction superseded.
+type archiveOp struct {
+	name   string
+	remove bool
+}
 
 // FilesystemLog is the log; see the package comment.
 type FilesystemLog struct {
@@ -136,19 +165,30 @@ type FilesystemLog struct {
 	spansMu sync.Mutex
 	spans   map[Revision][]logcodec.Span
 
-	// cache holds recently written and read records.
+	// cache holds recently written records (reads of the active file).
 	cache *recordcache.Cache
 
-	// mapMu serializes creating mappings.
+	// mapMu serializes creating mappings and guards retired.
 	mapMu sync.Mutex
+	// retired holds mappings of files removed by compaction until it is
+	// safe to unmap them.
+	retired []retiredMapping
 
-	// uploads carries closed files to the uploader goroutine.
-	uploads      chan string
+	// compactMu serializes compactions.
+	compactMu sync.Mutex
+
+	// archiveOps carries work to the uploader goroutine.
+	archiveOps   chan archiveOp
 	uploaderDone chan struct{}
 	stop         chan struct{}
 	rotatorDone  chan struct{}
 
 	removeOnClose bool
+}
+
+type retiredMapping struct {
+	mapped []byte
+	at     time.Time
 }
 
 var _ persistence.Log = &FilesystemLog{}
@@ -195,7 +235,7 @@ func NewFilesystemLogWithOptions(dir string, opts Options) (*FilesystemLog, erro
 		opts:         opts,
 		spans:        map[Revision][]logcodec.Span{},
 		cache:        recordcache.New(opts.CacheBytes),
-		uploads:      make(chan string, 1024),
+		archiveOps:   make(chan archiveOp, 4096),
 		uploaderDone: make(chan struct{}),
 		stop:         make(chan struct{}),
 		rotatorDone:  make(chan struct{}),
@@ -211,6 +251,9 @@ func NewFilesystemLogWithOptions(dir string, opts Options) (*FilesystemLog, erro
 	go l.rotator()
 	return l, nil
 }
+
+// Dir returns the log's directory.
+func (l *FilesystemLog) Dir() string { return l.dir }
 
 // open builds the index from the files in the directory (and the archive),
 // repairs a torn tail on the last file, and opens it for appending.
@@ -231,13 +274,13 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to read log file %s: %w", f.name, err)
 		}
-		spans, complete, err := logcodec.Scan(data)
+		spans, revisions, complete, err := logcodec.Scan(data)
 		if err != nil {
 			return fmt.Errorf("log file %s: %w", f.name, err)
 		}
 		if complete < len(data) {
-			if i < len(files)-1 {
-				return fmt.Errorf("log file %s is truncated at byte %d but is not the last file; recovery needed", f.name, complete)
+			if i < len(files)-1 || f.sparse {
+				return fmt.Errorf("log file %s is truncated at byte %d but is not the active file; recovery needed", f.name, complete)
 			}
 			// A write cut short by a crash: nothing past it was acknowledged.
 			klog.Warningf("log file %s ends in a torn record; truncating from %d to %d bytes", f.name, len(data), complete)
@@ -247,15 +290,30 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 		}
 		f.count = len(spans)
 		f.size = int64(complete)
+		if f.sparse {
+			for j, r := range revisions {
+				if r < f.first || r > f.last || (j > 0 && r <= revisions[j-1]) {
+					return fmt.Errorf("log file %s: record %d has revision %d, outside or out of order for %d-%d; recovery needed", f.name, j, r, f.first, f.last)
+				}
+			}
+			f.revisions = revisions
+		} else {
+			for j, r := range revisions {
+				if r != f.first+Revision(j) {
+					return fmt.Errorf("log file %s: record %d has revision %d, want %d; recovery needed", f.name, j, r, f.first+Revision(j))
+				}
+			}
+			f.last = f.first + Revision(f.count) - 1
+		}
 		if i > 0 {
 			prev := files[i-1]
-			if f.first != prev.first+Revision(prev.count) {
-				return fmt.Errorf("log has a gap: %s ends at revision %d but %s starts at %d; recovery needed", prev.name, prev.last(), f.name, f.first)
+			if f.first != prev.last+1 {
+				return fmt.Errorf("log has a gap: %s ends at revision %d but %s starts at %d; recovery needed", prev.name, prev.last, f.name, f.first)
 			}
 		} else if f.first != 1 {
 			return fmt.Errorf("log starts at revision %d, not 1; recovery needed", f.first)
 		}
-		if i == len(files)-1 {
+		if i == len(files)-1 && !f.sparse {
 			l.spans[f.first] = spans
 		}
 	}
@@ -265,21 +323,24 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 		return l.newActiveFile()
 	}
 	last := files[len(files)-1]
-	l.lastRevision = last.last()
+	l.lastRevision = last.last
 
 	// Closed files that never made it to the archive (a crash after
 	// rotating, before the upload finished).
 	if l.opts.Archive != nil {
 		for _, f := range files[:len(files)-1] {
 			if !f.archived {
-				l.uploads <- f.name
+				l.archiveOps <- archiveOp{name: f.name}
 			}
 		}
 	}
 
-	if last.archived {
+	if last.archived || last.sparse {
 		// An archived file is never appended to again (its object would no
-		// longer match); start the next one.
+		// longer match), nor is a compacted one; start the next file.
+		if !last.archived && l.opts.Archive != nil {
+			l.archiveOps <- archiveOp{name: last.name}
+		}
 		return l.newActiveFile()
 	}
 	l.active, err = os.OpenFile(filepath.Join(l.dir, last.name), os.O_WRONLY|os.O_APPEND, 0644)
@@ -290,7 +351,9 @@ func (l *FilesystemLog) open(ctx context.Context) error {
 	return nil
 }
 
-// listFiles returns the log files in the directory, sorted.
+// listFiles returns the log files in the directory, sorted, with files
+// superseded by a compacted file removed (a crash between writing the
+// compacted file and removing the originals leaves both).
 func (l *FilesystemLog) listFiles() ([]*logFile, error) {
 	entries, err := os.ReadDir(l.dir)
 	if err != nil {
@@ -301,29 +364,50 @@ func (l *FilesystemLog) listFiles() ([]*logFile, error) {
 		if e.IsDir() {
 			continue
 		}
-		first, err := filenameToRevision(e.Name())
+		first, last, sparse, err := parseFilename(e.Name())
 		if err != nil {
 			klog.Warningf("ignoring file with unexpected name %q: %v", e.Name(), err)
 			continue
 		}
-		files = append(files, &logFile{name: e.Name(), first: first})
+		files = append(files, &logFile{name: e.Name(), first: first, last: last, sparse: sparse})
 	}
-	slices.SortFunc(files, func(a, b *logFile) int { return int(a.first) - int(b.first) })
-	return files, nil
+	slices.SortFunc(files, func(a, b *logFile) int {
+		if a.first != b.first {
+			return int(a.first) - int(b.first)
+		}
+		// A compacted file sorts before the dense file it replaced.
+		if a.sparse != b.sparse {
+			if a.sparse {
+				return -1
+			}
+			return 1
+		}
+		return 0
+	})
+
+	var kept []*logFile
+	for _, f := range files {
+		if n := len(kept); n > 0 && kept[n-1].sparse && f.first >= kept[n-1].first && f.first <= kept[n-1].last {
+			klog.Infof("removing log file %s, superseded by compacted %s", f.name, kept[n-1].name)
+			if err := os.Remove(filepath.Join(l.dir, f.name)); err != nil {
+				return nil, fmt.Errorf("removing superseded log file %s: %w", f.name, err)
+			}
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept, nil
 }
 
 // reconcileArchive brings the directory and the archive into agreement: a
 // directory with no files is restored from the archive; otherwise every
-// archived file must be present locally (the archive is written only by
-// this log), and closed local files missing from the archive are uploaded.
+// archived file must be present locally or superseded by a local compacted
+// file (the archive is written only by this log), and closed local files
+// missing from the archive are uploaded.
 func (l *FilesystemLog) reconcileArchive(ctx context.Context, files []*logFile) ([]*logFile, error) {
 	names, err := l.opts.Archive.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing archive: %w", err)
-	}
-	archived := map[string]bool{}
-	for _, name := range names {
-		archived[name] = true
 	}
 
 	if len(files) == 0 && len(names) > 0 {
@@ -343,13 +427,29 @@ func (l *FilesystemLog) reconcileArchive(ctx context.Context, files []*logFile) 
 		local[f.name] = f
 	}
 	for _, name := range names {
-		f, ok := local[name]
-		if !ok {
-			return nil, fmt.Errorf("archive holds %s, which this log does not have; is another instance writing to the archive?", name)
+		if f, ok := local[name]; ok {
+			f.archived = true
+			continue
 		}
-		f.archived = true
+		first, _, _, err := parseFilename(name)
+		if err == nil && l.superseded(files, first) {
+			// Compaction replaced it locally but had not yet removed it.
+			l.archiveOps <- archiveOp{name: name, remove: true}
+			continue
+		}
+		return nil, fmt.Errorf("archive holds %s, which this log does not have; is another instance writing to the archive?", name)
 	}
 	return files, nil
+}
+
+// superseded reports whether a compacted file in files covers first.
+func (l *FilesystemLog) superseded(files []*logFile, first Revision) bool {
+	for _, f := range files {
+		if f.sparse && first >= f.first && first <= f.last {
+			return true
+		}
+	}
+	return false
 }
 
 // newActiveFile starts the file for revision lastRevision+1. Called with
@@ -374,7 +474,7 @@ func (l *FilesystemLog) newActiveFile() error {
 		f.Close()
 		return err
 	}
-	l.files = append(l.files, &logFile{name: name, first: first, size: int64(len(header)), opened: time.Now()})
+	l.files = append(l.files, &logFile{name: name, first: first, last: first - 1, size: int64(len(header)), opened: time.Now()})
 	l.spansMu.Lock()
 	l.spans[first] = nil
 	l.spansMu.Unlock()
@@ -387,10 +487,6 @@ func (l *FilesystemLog) Append(ctx context.Context, logRecord *LogRecord, txnMet
 	return l.batching.Add(ctx, logRecord, txnMeta)
 }
 
-type persistedBatch struct {
-	Records []*persistence.LogRecord
-}
-
 // commitBatch appends a batch to the active file, fsyncs it, and publishes
 // it. This is the commit point.
 func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revision, bc *batch.BatchCommit) error {
@@ -401,7 +497,7 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 	for i, txn := range bc.Transactions {
 		records[i] = txn.LogRecord
 	}
-	buf, spans, err := logcodec.AppendRecords(nil, records)
+	buf, spans, err := logcodec.AppendRecords(nil, lastLogPosition+1, records)
 	if err != nil {
 		return fmt.Errorf("failed to encode log records: %w", err)
 	}
@@ -436,6 +532,7 @@ func (l *FilesystemLog) commitBatch(ctx context.Context, lastLogPosition Revisio
 	active.count += len(records)
 	active.size += int64(len(buf))
 	l.lastRevision += Revision(len(records))
+	active.last = l.lastRevision
 	if l.listener != nil {
 		l.listener.OnLogEntry(l.lastRevision)
 	}
@@ -466,12 +563,12 @@ func (l *FilesystemLog) rotateLocked() error {
 	}
 	klog.V(2).Infof("rotated log file %s (%d records, %d bytes)", old.name, old.count, old.size)
 	if l.opts.Archive != nil {
-		l.uploads <- old.name
+		l.archiveOps <- archiveOp{name: old.name}
 	}
 	return nil
 }
 
-// rotator rotates the active file by age.
+// rotator rotates the active file by age, and unmaps retired mappings.
 func (l *FilesystemLog) rotator() {
 	defer close(l.rotatorDone)
 	ticker := time.NewTicker(time.Second)
@@ -492,35 +589,44 @@ func (l *FilesystemLog) rotator() {
 		}
 		l.mu.Unlock()
 		l.writeMu.Unlock()
+		l.unmapRetired(false)
 	}
 }
 
-// uploader copies closed files to the archive, retrying until each succeeds.
-// A conflict means another writer is using the archive, which is fatal.
+// uploader copies closed files to the archive and removes superseded ones,
+// retrying until each succeeds. A conflict means another writer is using
+// the archive, which is fatal.
 func (l *FilesystemLog) uploader(ctx context.Context) {
 	defer close(l.uploaderDone)
 	if l.opts.Archive == nil {
 		return
 	}
-	for name := range l.uploads {
+	for op := range l.archiveOps {
 		backoff := time.Second
 		for {
-			err := l.opts.Archive.Upload(ctx, name, filepath.Join(l.dir, name))
+			var err error
+			if op.remove {
+				err = l.opts.Archive.Delete(ctx, op.name)
+			} else {
+				err = l.opts.Archive.Upload(ctx, op.name, filepath.Join(l.dir, op.name))
+			}
 			if err == nil {
-				klog.V(2).Infof("archived log file %s", name)
-				l.mu.Lock()
-				for _, f := range l.files {
-					if f.name == name {
-						f.archived = true
+				if !op.remove {
+					klog.V(2).Infof("archived log file %s", op.name)
+					l.mu.Lock()
+					for _, f := range l.files {
+						if f.name == op.name {
+							f.archived = true
+						}
 					}
+					l.mu.Unlock()
 				}
-				l.mu.Unlock()
 				break
 			}
 			if errors.Is(err, persistence.ErrRevisionConflict) {
-				panic(fmt.Sprintf("archiving log file %s: %v", name, err))
+				panic(fmt.Sprintf("archiving log file %s: %v", op.name, err))
 			}
-			klog.Errorf("archiving log file %s (retrying in %s): %v", name, backoff, err)
+			klog.Errorf("archive operation on %s (retrying in %s): %v", op.name, backoff, err)
 			time.Sleep(backoff)
 			if backoff < 30*time.Second {
 				backoff *= 2
@@ -548,7 +654,7 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 	if aliased {
 		// Decode in place, aliasing the key and value bytes rather than
 		// copying them. Not cached: the cache is for the write-recent set,
-		// and a cached alias would pin the mapping.
+		// and a cached alias would pin the mapping past compaction.
 		record, err := logcodec.DecodeMessageAlias(m)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode log record %d: %w", revision, err)
@@ -575,7 +681,6 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 	if !ok {
 		return nil, false, fmt.Errorf("log entry for revision %d not found in any file", revision)
 	}
-	pos := int(revision - f.first)
 
 	if !active {
 		m, err := l.mapping(f)
@@ -587,8 +692,9 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 			if err != nil {
 				return nil, false, err
 			}
-			if pos < 0 || pos >= len(spans) {
-				return nil, false, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+			pos, err := f.position(revision, len(spans))
+			if err != nil {
+				return nil, false, err
 			}
 			span := spans[pos]
 			return m[span.Offset : span.Offset+span.Length], true, nil
@@ -599,8 +705,9 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 	if err != nil {
 		return nil, false, err
 	}
-	if pos < 0 || pos >= len(spans) {
-		return nil, false, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+	pos, err := f.position(revision, len(spans))
+	if err != nil {
+		return nil, false, err
 	}
 	span := spans[pos]
 	file, err := l.reader(f)
@@ -612,6 +719,23 @@ func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, 
 		return nil, false, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
 	}
 	return buf, false, nil
+}
+
+// position returns the index of revision's record in the file, or
+// ErrCompacted if the file is sparse and compaction dropped it.
+func (f *logFile) position(revision Revision, count int) (int, error) {
+	if !f.sparse {
+		pos := int(revision - f.first)
+		if pos < 0 || pos >= count {
+			return 0, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, count)
+		}
+		return pos, nil
+	}
+	pos := sort.Search(len(f.revisions), func(i int) bool { return f.revisions[i] >= revision })
+	if pos >= len(f.revisions) || f.revisions[pos] != revision {
+		return 0, fmt.Errorf("revision %d: %w", revision, persistence.ErrCompacted)
+	}
+	return pos, nil
 }
 
 // mapping returns a closed file's memory mapping, creating it on first use
@@ -658,24 +782,6 @@ func (l *FilesystemLog) readerLocked(f *logFile) (*os.File, error) {
 	return f.reader, nil
 }
 
-// fileSpansFrom is fileSpans for a file whose bytes are already at hand.
-func (l *FilesystemLog) fileSpansFrom(f *logFile, data []byte) ([]logcodec.Span, error) {
-	l.spansMu.Lock()
-	spans, ok := l.spans[f.first]
-	l.spansMu.Unlock()
-	if ok {
-		return spans, nil
-	}
-	spans, err := logcodec.Offsets(data)
-	if err != nil {
-		return nil, fmt.Errorf("indexing log file %s: %w", f.name, err)
-	}
-	l.spansMu.Lock()
-	l.spans[f.first] = spans
-	l.spansMu.Unlock()
-	return spans, nil
-}
-
 // fileSpans returns the record spans of a file, scanning its length
 // prefixes on first use for closed files.
 func (l *FilesystemLog) fileSpans(f *logFile) ([]logcodec.Span, error) {
@@ -689,7 +795,18 @@ func (l *FilesystemLog) fileSpans(f *logFile) ([]logcodec.Span, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read log file %s: %w", f.name, err)
 	}
-	spans, err = logcodec.Offsets(data)
+	return l.fileSpansFrom(f, data)
+}
+
+// fileSpansFrom is fileSpans for a file whose bytes are already at hand.
+func (l *FilesystemLog) fileSpansFrom(f *logFile, data []byte) ([]logcodec.Span, error) {
+	l.spansMu.Lock()
+	spans, ok := l.spans[f.first]
+	l.spansMu.Unlock()
+	if ok {
+		return spans, nil
+	}
+	spans, _, err := logcodec.Offsets(data)
 	if err != nil {
 		return nil, fmt.Errorf("indexing log file %s: %w", f.name, err)
 	}
@@ -699,13 +816,13 @@ func (l *FilesystemLog) fileSpans(f *logFile) ([]logcodec.Span, error) {
 	return spans, nil
 }
 
-// findFile finds the file containing revision. Called with mu held.
+// findFile finds the file covering revision. Called with mu held.
 func (l *FilesystemLog) findFile(revision Revision) (*logFile, bool) {
 	// Recent revisions are the most requested; search from the end.
 	for i := len(l.files) - 1; i >= 0; i-- {
 		f := l.files[i]
 		if f.first <= revision {
-			return f, revision <= f.last()
+			return f, revision <= f.last
 		}
 	}
 	return nil, false
@@ -722,7 +839,7 @@ func (l *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 	l.mu.RUnlock()
 
 	for i, f := range files {
-		if f.count == 0 || f.last() < fromRevision {
+		if f.count == 0 || f.last < fromRevision {
 			continue
 		}
 		// Read only what was published; the active file may be growing.
@@ -736,21 +853,227 @@ func (l *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 		if err != nil {
 			return fmt.Errorf("failed to read log file %s: %w", f.name, err)
 		}
-		records, err := logcodec.Decode(data)
+		spans, revisions, err := logcodec.Offsets(data)
 		if err != nil {
 			return fmt.Errorf("failed to decode log file %s: %w", f.name, err)
 		}
-		for j, record := range records {
-			revision := f.first + Revision(j)
-			if revision < fromRevision {
+		for j, span := range spans {
+			if revisions[j] < fromRevision {
 				continue
 			}
-			if !callback(revision, record) {
+			record, err := logcodec.DecodeMessage(data[span.Offset : span.Offset+span.Length])
+			if err != nil {
+				return fmt.Errorf("failed to decode log record %d from file %s: %w", revisions[j], f.name, err)
+			}
+			if !callback(revisions[j], record) {
 				return nil
 			}
 		}
 	}
 	return nil
+}
+
+// Compact rewrites the closed files at or below through, keeping only their
+// live records: puts that live(key, revision) confirms are still the latest
+// for their key. Deletes and superseded puts are dropped. Files are merged
+// while the result stays under RotateBytes; a compacted file that is still
+// mostly live is left alone. The originals are removed (from the archive
+// too) once the replacement is durable.
+func (l *FilesystemLog) Compact(ctx context.Context, through Revision, live func(key []byte, revision Revision) bool) error {
+	l.compactMu.Lock()
+	defer l.compactMu.Unlock()
+
+	l.mu.RLock()
+	var eligible []*logFile
+	for _, f := range l.files[:len(l.files)-1] {
+		if f.last <= through {
+			eligible = append(eligible, f)
+		}
+	}
+	l.mu.RUnlock()
+
+	// Group consecutive files by their live bytes so that each output stays
+	// under RotateBytes: a dense file that is mostly dead merges with its
+	// neighbours; a mostly live one stays on its own.
+	var group []*logFile
+	var groupBytes int64
+	flush := func() error {
+		if len(group) == 0 {
+			return nil
+		}
+		err := l.compactGroup(ctx, group, live)
+		group, groupBytes = nil, 0
+		return err
+	}
+	for _, f := range eligible {
+		var liveBytes int64
+		if _, err := l.liveRecords(f, live, func(m []byte, rev Revision) { liveBytes += int64(len(m)) + 4 }); err != nil {
+			return err
+		}
+		if groupBytes > 0 && groupBytes+liveBytes > l.opts.RotateBytes {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		group = append(group, f)
+		groupBytes += liveBytes
+	}
+	return flush()
+}
+
+// compactGroup replaces a run of consecutive closed files with one file
+// holding their live records.
+func (l *FilesystemLog) compactGroup(ctx context.Context, group []*logFile, live func(key []byte, revision Revision) bool) error {
+	first, last := group[0].first, group[len(group)-1].last
+	name := rangeToFilename(first, last)
+	if len(group) == 1 && group[0].name == name {
+		// Already compacted into this exact file; see whether it has rotted.
+		if dead, err := l.liveRecords(group[0], live, nil); err != nil {
+			return err
+		} else if dead*10 < group[0].count {
+			return nil
+		}
+	}
+
+	buf := append([]byte(nil), logcodec.Header()...)
+	var revisions []Revision
+	var spans []logcodec.Span
+	var kept int
+	for _, f := range group {
+		if _, err := l.liveRecords(f, live, func(m []byte, rev Revision) {
+			var span logcodec.Span
+			buf, span = logcodec.AppendRaw(buf, m)
+			spans = append(spans, span)
+			revisions = append(revisions, rev)
+			kept++
+		}); err != nil {
+			return err
+		}
+	}
+
+	tmp := filepath.Join(l.dir, name+".tmp")
+	if err := os.WriteFile(tmp, buf, 0644); err != nil {
+		return fmt.Errorf("writing compacted log file %s: %w", name, err)
+	}
+	if err := syncFile(tmp); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, filepath.Join(l.dir, name)); err != nil {
+		return fmt.Errorf("renaming compacted log file %s: %w", name, err)
+	}
+	if err := syncDir(l.dir); err != nil {
+		return err
+	}
+	compacted := &logFile{name: name, first: first, last: last, sparse: true, revisions: revisions, count: kept, size: int64(len(buf)), opened: time.Now(), archived: false}
+
+	// Swap it into the index, retire the originals' mappings, and remove
+	// the originals.
+	l.mu.Lock()
+	i := slices.Index(l.files, group[0])
+	l.files = slices.Replace(l.files, i, i+len(group), compacted)
+	l.spansMu.Lock()
+	for _, f := range group {
+		delete(l.spans, f.first)
+	}
+	l.spans[first] = spans
+	l.spansMu.Unlock()
+	l.mu.Unlock()
+
+	l.mapMu.Lock()
+	for _, f := range group {
+		if f.mapped != nil {
+			l.retired = append(l.retired, retiredMapping{mapped: f.mapped, at: time.Now()})
+			f.mapped = nil
+		}
+		if f.reader != nil && f.name != name {
+			f.reader.Close()
+			f.reader = nil
+		}
+	}
+	l.mapMu.Unlock()
+
+	var oldBytes int64
+	for _, f := range group {
+		oldBytes += f.size
+		if f.name == name {
+			continue
+		}
+		if err := os.Remove(filepath.Join(l.dir, f.name)); err != nil {
+			klog.Errorf("removing compacted-away log file %s: %v", f.name, err)
+		}
+	}
+	klog.V(1).Infof("compacted %d file(s) covering revisions %d-%d into %s: %d records kept, %d MB -> %d MB",
+		len(group), first, last, name, kept, oldBytes>>20, compacted.size>>20)
+
+	if l.opts.Archive != nil {
+		l.archiveOps <- archiveOp{name: name}
+		for _, f := range group {
+			if f.name != name {
+				l.archiveOps <- archiveOp{name: f.name, remove: true}
+			}
+		}
+	}
+	return nil
+}
+
+// liveRecords scans a closed file, calling keep for each live record with
+// its raw bytes and revision, and returns the number of records dropped. A
+// record is live if any of its puts is still the latest for its key;
+// deletes are never live.
+func (l *FilesystemLog) liveRecords(f *logFile, live func(key []byte, revision Revision) bool, keep func(m []byte, rev Revision)) (int, error) {
+	data, err := l.mapping(f)
+	if err != nil {
+		return 0, err
+	}
+	if data == nil {
+		if data, err = os.ReadFile(filepath.Join(l.dir, f.name)); err != nil {
+			return 0, fmt.Errorf("failed to read log file %s: %w", f.name, err)
+		}
+	}
+	spans, revisions, err := logcodec.Offsets(data)
+	if err != nil {
+		return 0, fmt.Errorf("indexing log file %s: %w", f.name, err)
+	}
+	dropped := 0
+	for i, span := range spans {
+		m := data[span.Offset : span.Offset+span.Length]
+		record, err := logcodec.DecodeMessageAlias(m)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode log record %d from file %s: %w", revisions[i], f.name, err)
+		}
+		isLive := false
+		for _, ev := range record.Events {
+			if ev.Type == mvccpb.PUT && live(ev.Kv.Key, revisions[i]) {
+				isLive = true
+				break
+			}
+		}
+		if !isLive {
+			dropped++
+			continue
+		}
+		if keep != nil {
+			keep(m, revisions[i])
+		}
+	}
+	return dropped, nil
+}
+
+// unmapRetired unmaps mappings retired long enough ago (or all of them).
+func (l *FilesystemLog) unmapRetired(all bool) {
+	l.mapMu.Lock()
+	defer l.mapMu.Unlock()
+	kept := l.retired[:0]
+	for _, r := range l.retired {
+		if all || time.Since(r.at) >= unmapAfter {
+			if err := munmapFile(r.mapped); err != nil {
+				klog.Errorf("unmapping retired log file: %v", err)
+			}
+			continue
+		}
+		kept = append(kept, r)
+	}
+	l.retired = kept
 }
 
 // Close flushes queued transactions, rotates the active file so that
@@ -776,13 +1099,14 @@ func (l *FilesystemLog) Close() error {
 	l.mu.Unlock()
 	l.writeMu.Unlock()
 
-	close(l.uploads)
+	close(l.archiveOps)
 	select {
 	case <-l.uploaderDone:
 	case <-time.After(30 * time.Second):
-		klog.Warningf("log closed with uploads still pending; they will resume on the next start")
+		klog.Warningf("log closed with archive operations still pending; they will resume on the next start")
 	}
 
+	l.unmapRetired(true)
 	l.mapMu.Lock()
 	for _, f := range l.files {
 		if err := munmapFile(f.mapped); err != nil {
@@ -813,6 +1137,16 @@ func (l *FilesystemLog) SetListener(listener LogListener) {
 	l.listener = listener
 }
 
+// syncFile fsyncs a file.
+func syncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
 // syncDir fsyncs a directory so that new directory entries are durable.
 func syncDir(dir string) error {
 	d, err := os.Open(dir)
@@ -823,19 +1157,35 @@ func syncDir(dir string) error {
 	return d.Sync()
 }
 
-// revisionToFilename names the file whose first record has this revision.
+// revisionToFilename names a dense file by its first revision.
 func revisionToFilename(first Revision) string {
 	return fmt.Sprintf("%016x.log", uint64(first))
 }
 
-// filenameToRevision is the inverse of revisionToFilename.
-func filenameToRevision(filename string) (Revision, error) {
+// rangeToFilename names a compacted file by the revision range it covers.
+func rangeToFilename(first, last Revision) string {
+	return fmt.Sprintf("%016x-%016x.log", uint64(first), uint64(last))
+}
+
+// parseFilename is the inverse of revisionToFilename and rangeToFilename.
+// A dense file's last revision is not in its name (it is derived from its
+// record count) and is returned as 0.
+func parseFilename(filename string) (first, last Revision, sparse bool, err error) {
 	if !strings.HasSuffix(filename, ".log") {
-		return 0, fmt.Errorf("invalid filename format: %s", filename)
+		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
 	}
-	n, err := strconv.ParseUint(strings.TrimSuffix(filename, ".log"), 16, 64)
+	base := strings.TrimSuffix(filename, ".log")
+	parts := strings.SplitN(base, "-", 2)
+	f, err := strconv.ParseUint(parts[0], 16, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid filename format: %s", filename)
+		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
 	}
-	return Revision(n), nil
+	if len(parts) == 1 {
+		return Revision(f), 0, false, nil
+	}
+	l, err := strconv.ParseUint(parts[1], 16, 64)
+	if err != nil || l < f {
+		return 0, 0, false, fmt.Errorf("invalid filename format: %s", filename)
+	}
+	return Revision(f), Revision(l), true, nil
 }

--- a/pkg/persistence/filesystemlog/filesystem_log_test.go
+++ b/pkg/persistence/filesystemlog/filesystem_log_test.go
@@ -15,9 +15,11 @@
 package filesystemlog
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -444,5 +446,161 @@ func TestTornTail(t *testing.T) {
 		if _, err := log2.GetLogEntry(r); err != nil {
 			t.Fatalf("GetLogEntry(%d) after repair: %v", r, err)
 		}
+	}
+}
+
+func putRec(key string, size int) *persistence.LogRecord {
+	return &persistence.LogRecord{Events: []*mvccpb.Event{{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(key), Value: make([]byte, size)}}}}
+}
+
+func delRec(key string) *persistence.LogRecord {
+	return &persistence.LogRecord{Events: []*mvccpb.Event{{Type: mvccpb.DELETE, Kv: &mvccpb.KeyValue{Key: []byte(key)}}}}
+}
+
+// TestCompaction writes keys that are overwritten and deleted across many
+// small files, compacts, and checks that files shrink to their live records,
+// that every live revision still reads, that compacted-away revisions fail
+// with ErrCompacted, and that a reopened log has exactly the same live state
+// and continues at the right revision.
+func TestCompaction(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	opts := Options{RotateBytes: 2000, CacheBytes: 1}
+	log, err := NewFilesystemLogWithOptions(dir, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// latest[key] is the revision of the key's latest put, or 0 if deleted.
+	latest := map[string]persistence.Revision{}
+	add := func(rec *persistence.LogRecord) persistence.Revision {
+		t.Helper()
+		rev, ok, err := log.Append(ctx, rec, persistence.NewTxnMeta(0))
+		if err != nil || !ok {
+			t.Fatalf("append: ok=%v err=%v", ok, err)
+		}
+		return rev
+	}
+	// 20 keys, each overwritten 10 times; every third key deleted at the end.
+	for round := 0; round < 10; round++ {
+		for k := 0; k < 20; k++ {
+			key := fmt.Sprintf("k%02d", k)
+			latest[key] = add(putRec(key, 100))
+		}
+	}
+	for k := 0; k < 20; k += 3 {
+		key := fmt.Sprintf("k%02d", k)
+		add(delRec(key))
+		latest[key] = 0
+	}
+	// A few more writes so the deletes are in a closed file.
+	for k := 0; k < 20; k++ {
+		if k%3 != 0 {
+			key := fmt.Sprintf("k%02d", k)
+			latest[key] = add(putRec(key, 100))
+		}
+	}
+	head, _ := log.GetCurrentRevision(ctx)
+	before, _ := os.ReadDir(dir)
+	var beforeBytes int64
+	for _, e := range before {
+		info, _ := e.Info()
+		beforeBytes += info.Size()
+	}
+
+	live := func(key []byte, rev persistence.Revision) bool { return latest[string(key)] == rev }
+	if err := log.Compact(ctx, head, live); err != nil {
+		t.Fatal(err)
+	}
+
+	after, _ := os.ReadDir(dir)
+	var afterBytes int64
+	for _, e := range after {
+		info, _ := e.Info()
+		afterBytes += info.Size()
+	}
+	if afterBytes*3 > beforeBytes {
+		t.Fatalf("compaction left %d of %d bytes; expected most of the history gone", afterBytes, beforeBytes)
+	}
+	if len(after) >= len(before) {
+		t.Fatalf("compaction left %d files (was %d); expected merging", len(after), len(before))
+	}
+	for _, e := range after {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("temporary file left behind: %s", e.Name())
+		}
+	}
+
+	check := func(log *FilesystemLog) {
+		t.Helper()
+		for key, rev := range latest {
+			if rev == 0 {
+				continue
+			}
+			rec, err := log.GetLogEntry(rev)
+			if err != nil {
+				t.Fatalf("GetLogEntry(%d) for live %s: %v", rev, key, err)
+			}
+			if string(rec.Events[0].Kv.Key) != key {
+				t.Fatalf("GetLogEntry(%d) = %s, want %s", rev, rec.Events[0].Kv.Key, key)
+			}
+		}
+		// The first write of k01 was superseded long ago.
+		if _, err := log.GetLogEntry(2); !errors.Is(err, persistence.ErrCompacted) {
+			t.Fatalf("GetLogEntry(2) = %v, want ErrCompacted", err)
+		}
+		if rev, _ := log.GetCurrentRevision(ctx); rev != head {
+			t.Fatalf("revision %d after compaction, want %d", rev, head)
+		}
+		// Replay yields exactly the live records, in revision order.
+		var seen []persistence.Revision
+		if err := log.Read(ctx, 1, func(r persistence.Revision, rec *persistence.LogRecord) bool {
+			seen = append(seen, r)
+			return true
+		}); err != nil {
+			t.Fatal(err)
+		}
+		for i := 1; i < len(seen); i++ {
+			if seen[i] <= seen[i-1] {
+				t.Fatalf("replay out of order at %v", seen[i-1:i+1])
+			}
+		}
+		liveCount := 0
+		for _, rev := range latest {
+			if rev != 0 {
+				liveCount++
+			}
+		}
+		// Everything in closed files is live; the active file may hold a
+		// few superseded records (it is not compacted).
+		if len(seen) < liveCount {
+			t.Fatalf("replay saw %d records, fewer than the %d live keys", len(seen), liveCount)
+		}
+	}
+	check(log)
+	if err := log.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	log2, err := NewFilesystemLogWithOptions(dir, opts)
+	if err != nil {
+		t.Fatalf("reopening a compacted log: %v", err)
+	}
+	defer log2.Close()
+	log = log2
+	check(log2)
+	if rev, ok, err := log2.Append(ctx, putRec("new", 10), persistence.NewTxnMeta(0)); err != nil || !ok || rev != head+1 {
+		t.Fatalf("append after reopen: rev=%d ok=%v err=%v", rev, ok, err)
+	}
+
+	// A second compaction with nothing new to drop is a no-op that keeps the
+	// compacted files as they are.
+	names1, _ := os.ReadDir(dir)
+	if err := log2.Compact(ctx, head, live); err != nil {
+		t.Fatal(err)
+	}
+	names2, _ := os.ReadDir(dir)
+	if len(names1) != len(names2) {
+		t.Fatalf("idempotent compaction changed the files: %d -> %d", len(names1), len(names2))
 	}
 }

--- a/pkg/persistence/filesystemlog/worker.go
+++ b/pkg/persistence/filesystemlog/worker.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystemlog
+
+import "time"
+
+// worker runs a function over queued items, in order, on its own goroutine.
+// It is the shape of the log's background work: callers add items and
+// never wait for them; stop drains the queue.
+type worker[T any] struct {
+	queue chan T
+	done  chan struct{}
+}
+
+// newWorker makes a worker whose queue holds capacity items. Items can be
+// added before start; nothing runs until it is called.
+func newWorker[T any](capacity int) *worker[T] {
+	return &worker[T]{queue: make(chan T, capacity), done: make(chan struct{})}
+}
+
+// start runs fn on each queued item, on a new goroutine.
+func (w *worker[T]) start(fn func(T)) {
+	go func() {
+		defer close(w.done)
+		for item := range w.queue {
+			fn(item)
+		}
+	}()
+}
+
+// add queues an item, blocking if the queue is full.
+func (w *worker[T]) add(item T) { w.queue <- item }
+
+// stop closes the queue and waits up to timeout for the worker to finish
+// the items in it. It reports whether the worker finished.
+func (w *worker[T]) stop(timeout time.Duration) bool {
+	close(w.queue)
+	select {
+	case <-w.done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// ticker calls a function every interval, on its own goroutine, until
+// stopped.
+type ticker struct {
+	stopping chan struct{}
+	done     chan struct{}
+}
+
+func startTicker(interval time.Duration, fn func()) *ticker {
+	t := &ticker{stopping: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(t.done)
+		tick := time.NewTicker(interval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-t.stopping:
+				return
+			case <-tick.C:
+				fn()
+			}
+		}
+	}()
+	return t
+}
+
+// stop stops the ticker and waits for a call in progress to return.
+func (t *ticker) stop() {
+	close(t.stopping)
+	<-t.done
+}

--- a/pkg/persistence/gcsarchive/archive_test.go
+++ b/pkg/persistence/gcsarchive/archive_test.go
@@ -109,6 +109,19 @@ func TestArchive(t *testing.T) {
 		t.Fatalf("upload of a different file under an existing name: got %v, want ErrRevisionConflict", err)
 	}
 
+	if err := a.Delete(ctx, "0000000000000002.log"); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Delete(ctx, "0000000000000002.log"); err != nil {
+		t.Fatalf("deleting a missing object should succeed: %v", err)
+	}
+	if names, _ := a.List(ctx); fmt.Sprint(names) != "[0000000000000001.log]" {
+		t.Fatalf("after delete: %v", names)
+	}
+	if err := a.Upload(ctx, "0000000000000002.log", two); err != nil {
+		t.Fatal(err)
+	}
+
 	got := filepath.Join(dir, "restored.log")
 	if err := a.Download(ctx, "0000000000000002.log", got); err != nil {
 		t.Fatal(err)
@@ -214,4 +227,83 @@ func TestLogArchivesAndRestores(t *testing.T) {
 		t.Fatal("a log with its own files opened against an archive holding other files")
 	}
 	_ = time.Second
+}
+
+// TestCompactionReplacesArchivedFiles checks that compacting a log with an
+// archive uploads the compacted file and removes the originals from the
+// archive, and that a fresh directory restores from the compacted archive.
+func TestCompactionReplacesArchivedFiles(t *testing.T) {
+	startEmulator(t, "cloudetcd-test")
+	ctx := t.Context()
+	a, err := New(ctx, "cloudetcd-test", "logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+
+	opts := filesystemlog.Options{Archive: a, RotateBytes: 300, CacheBytes: 1}
+	log1, err := filesystemlog.NewFilesystemLogWithOptions(t.TempDir(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest := map[string]persistence.Revision{}
+	for round := 0; round < 10; round++ {
+		for k := 0; k < 5; k++ {
+			key := fmt.Sprintf("k%d", k)
+			snapshot, _ := log1.GetCurrentRevision(ctx)
+			meta := persistence.NewTxnMeta(snapshot)
+			meta.AddWrite(key)
+			rev, ok, err := log1.Append(ctx, put(key), meta)
+			if err != nil || !ok {
+				t.Fatalf("append %s round %d: ok=%v err=%v", key, round, ok, err)
+			}
+			latest[key] = rev
+		}
+	}
+	head, _ := log1.GetCurrentRevision(ctx)
+	// Rotate so everything is closed and archived before compacting.
+	if err := log1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	dir := log1.Dir()
+	log1, err = filesystemlog.NewFilesystemLogWithOptions(dir, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _ := a.List(ctx)
+	if err := log1.Compact(ctx, head, func(key []byte, rev persistence.Revision) bool { return latest[string(key)] == rev }); err != nil {
+		t.Fatal(err)
+	}
+	if err := log1.Close(); err != nil { // waits for archive operations
+		t.Fatal(err)
+	}
+	after, _ := a.List(ctx)
+	if len(after) >= len(before) {
+		t.Fatalf("archive has %d files after compaction (was %d); expected the originals replaced", len(after), len(before))
+	}
+	var sparse int
+	for _, n := range after {
+		if strings.Contains(n, "-") {
+			sparse++
+		}
+	}
+	if sparse == 0 {
+		t.Fatalf("no compacted file in the archive: %v", after)
+	}
+
+	// A fresh directory restores the compacted archive and has the live state.
+	log2, err := filesystemlog.NewFilesystemLogWithOptions(t.TempDir(), opts)
+	if err != nil {
+		t.Fatalf("restoring a compacted archive: %v", err)
+	}
+	defer log2.Close()
+	if rev, _ := log2.GetCurrentRevision(ctx); rev != head {
+		t.Fatalf("restored log at revision %d, want %d", rev, head)
+	}
+	for key, rev := range latest {
+		rec, err := log2.GetLogEntry(rev)
+		if err != nil || string(rec.Events[0].Kv.Key) != key {
+			t.Fatalf("GetLogEntry(%d) for %s after restore: %v, %v", rev, key, rec, err)
+		}
+	}
 }

--- a/pkg/persistence/gcsarchive/gcsarchive.go
+++ b/pkg/persistence/gcsarchive/gcsarchive.go
@@ -135,6 +135,15 @@ func (a *Archive) explainWriteError(ctx context.Context, obj *storage.ObjectHand
 		name, attrs.Size, attrs.CRC32C, size, crc, persistence.ErrRevisionConflict)
 }
 
+// Delete removes object name; a missing object is not an error.
+func (a *Archive) Delete(ctx context.Context, name string) error {
+	err := a.bucket.Object(a.prefix + name).Delete(ctx)
+	if err == nil || errors.Is(err, storage.ErrObjectNotExist) {
+		return nil
+	}
+	return fmt.Errorf("deleting %s from GCS: %w", name, err)
+}
+
 // Download copies object name to the file at path.
 func (a *Archive) Download(ctx context.Context, name string, path string) error {
 	r, err := a.bucket.Object(a.prefix + name).NewReader(ctx)

--- a/pkg/persistence/log.go
+++ b/pkg/persistence/log.go
@@ -30,6 +30,10 @@ type Revision uint64
 // it can append again.
 var ErrRevisionConflict = errors.New("log revision already claimed by another writer")
 
+// ErrCompacted is returned when a revision below the compaction point is
+// requested: its history has been discarded.
+var ErrCompacted = errors.New("revision has been compacted")
+
 // LogRecord represents a single entry in the log
 type LogRecord struct {
 	// Events are the events that occurred as a result of this record
@@ -65,6 +69,12 @@ type Log interface {
 
 	// SetListener sets the log listener
 	SetListener(listener LogListener)
+
+	// Compact discards records at or below through that are no longer live:
+	// deletes, and puts that live(key, revision) reports have been
+	// superseded. Records above through, and the latest put of every key,
+	// are kept. Reads of discarded revisions fail with ErrCompacted.
+	Compact(ctx context.Context, through Revision, live func(key []byte, revision Revision) bool) error
 }
 
 // LogListener is the interface for the persistence log

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package logcodec is the on-disk / in-object encoding of a batch of log
-// records, shared by the file and object-store logs.
+// Package logcodec is the on-disk encoding of a log file.
 //
-// A batch is a fixed header followed by one length-delimited protobuf
-// message per record. Each record is an etcdserverpb.WatchResponse carrying
-// the record's events: the events are already mvccpb.Event protobufs, so
-// this needs no generated code of its own, values are stored as raw bytes
-// rather than base64, and decoding is several times faster than the JSON
-// encoding it replaces.
+// A file is a fixed header followed by one length-delimited protobuf message
+// per record, appended over time. Each record is an etcdserverpb.WatchResponse
+// carrying the record's revision (in its header) and events: the events are
+// already mvccpb.Event protobufs, so this needs no generated code of our
+// own, and values are stored as raw bytes. Because every record carries its
+// revision, a file may be sparse in revision (a compacted file holds only the
+// records that were still live).
 package logcodec
 
 import (
@@ -43,25 +43,46 @@ var magic = []byte("cloudetcd-log\x00\x01")
 // Header is what a log file starts with.
 func Header() []byte { return magic }
 
-// Encode serializes records as a whole file: Header followed by the records.
-func Encode(records []*persistence.LogRecord) ([]byte, error) {
-	return EncodeRecords(append([]byte(nil), magic...), records)
-}
-
-// EncodeRecords appends the encoding of records to buf, for appending to a
-// file that already has its header.
-func EncodeRecords(buf []byte, records []*persistence.LogRecord) ([]byte, error) {
-	buf, _, err := AppendRecords(buf, records)
+// Encode serializes records as a whole file: Header followed by the records,
+// with revisions first, first+1, ...
+func Encode(first persistence.Revision, records []*persistence.LogRecord) ([]byte, error) {
+	buf, _, err := AppendRecords(append([]byte(nil), magic...), first, records)
 	return buf, err
 }
 
-// AppendRecords is EncodeRecords that also returns each record's Span
-// relative to the start of buf.
-func AppendRecords(buf []byte, records []*persistence.LogRecord) ([]byte, []Span, error) {
+// AppendRecords appends the encoding of records to buf (for appending to a
+// file that already has its header), giving them revisions first, first+1,
+// ... It returns each record's Span relative to the start of buf.
+func AppendRecords(buf []byte, first persistence.Revision, records []*persistence.LogRecord) ([]byte, []Span, error) {
+	revisions := make([]persistence.Revision, len(records))
+	for i := range revisions {
+		revisions[i] = first + persistence.Revision(i)
+	}
+	return AppendRecordsAt(buf, revisions, records)
+}
+
+// AppendRaw appends one already-encoded record (the bytes of a Span) to buf,
+// returning its Span relative to the start of buf. Compaction copies records
+// between files this way, without decoding them.
+func AppendRaw(buf []byte, m []byte) ([]byte, Span) {
+	buf = protowire.AppendVarint(buf, uint64(len(m)))
+	span := Span{Offset: len(buf), Length: len(m)}
+	return append(buf, m...), span
+}
+
+// AppendRecordsAt is AppendRecords with an explicit revision per record, for
+// files that are sparse in revision.
+func AppendRecordsAt(buf []byte, revisions []persistence.Revision, records []*persistence.LogRecord) ([]byte, []Span, error) {
+	if len(revisions) != len(records) {
+		return nil, nil, fmt.Errorf("%d revisions for %d records", len(revisions), len(records))
+	}
 	opts := proto.MarshalOptions{}
 	spans := make([]Span, 0, len(records))
 	for i, r := range records {
-		m, err := opts.MarshalAppend(nil, &etcdserverpb.WatchResponse{Events: r.Events})
+		m, err := opts.MarshalAppend(nil, &etcdserverpb.WatchResponse{
+			Header: &etcdserverpb.ResponseHeader{Revision: int64(revisions[i])},
+			Events: r.Events,
+		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("encoding record %d: %w", i, err)
 		}
@@ -104,28 +125,29 @@ type Span struct {
 	Length int
 }
 
-// Offsets returns the span of every record in a file without decoding any
-// of them: it reads only the length prefixes. With the spans, a record can be
-// read from storage by itself (see DecodeMessage). A truncated final record
-// is an error; see Scan for recovering a file with a torn tail.
-func Offsets(data []byte) ([]Span, error) {
-	spans, complete, err := Scan(data)
+// Offsets returns the span and revision of every record in a file without
+// decoding the records: it reads the length prefixes and each record's
+// header. With a span, a record can be read from storage by itself (see
+// DecodeMessage). A truncated final record is an error; see Scan for
+// recovering a file with a torn tail.
+func Offsets(data []byte) ([]Span, []persistence.Revision, error) {
+	spans, revisions, complete, err := Scan(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if complete != len(data) {
-		return nil, fmt.Errorf("decoding record %d: truncated", len(spans))
+		return nil, nil, fmt.Errorf("decoding record %d: truncated", len(spans))
 	}
-	return spans, nil
+	return spans, revisions, nil
 }
 
-// Scan returns the spans of the complete records in a file, and the number
-// of bytes they occupy including the header. If complete < len(data), the
-// file ends in a torn record (a write that was cut short); the file's valid
-// content is data[:complete].
-func Scan(data []byte) (spans []Span, complete int, err error) {
+// Scan returns the spans and revisions of the complete records in a file,
+// and the number of bytes they occupy including the header. If complete <
+// len(data), the file ends in a torn record (a write that was cut short);
+// the file's valid content is data[:complete].
+func Scan(data []byte) (spans []Span, revisions []persistence.Revision, complete int, err error) {
 	if !bytes.HasPrefix(data, magic) {
-		return nil, 0, fmt.Errorf("not a cloudetcd log file (bad header)")
+		return nil, nil, 0, fmt.Errorf("not a cloudetcd log file (bad header)")
 	}
 	pos := len(magic)
 	for pos < len(data) {
@@ -133,18 +155,68 @@ func Scan(data []byte) (spans []Span, complete int, err error) {
 		if k < 0 {
 			if perr := protowire.ParseError(k); errors.Is(perr, io.ErrUnexpectedEOF) {
 				// Not enough bytes for the length prefix: a torn tail.
-				return spans, pos, nil
+				return spans, revisions, pos, nil
 			} else {
-				return nil, 0, fmt.Errorf("decoding record %d: %w", len(spans), perr)
+				return nil, nil, 0, fmt.Errorf("decoding record %d: %w", len(spans), perr)
 			}
 		}
 		if uint64(len(data)-pos-k) < n {
-			return spans, pos, nil
+			return spans, revisions, pos, nil
+		}
+		m := data[pos+k : pos+k+int(n)]
+		rev, err := recordRevision(m)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("decoding record %d: %w", len(spans), err)
 		}
 		spans = append(spans, Span{Offset: pos + k, Length: int(n)})
+		revisions = append(revisions, rev)
 		pos += k + int(n)
 	}
-	return spans, pos, nil
+	return spans, revisions, pos, nil
+}
+
+// recordRevision reads the revision from a record's header without decoding
+// the rest (WatchResponse field 1, ResponseHeader field 3).
+func recordRevision(m []byte) (persistence.Revision, error) {
+	for len(m) > 0 {
+		num, typ, n := protowire.ConsumeTag(m)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		m = m[n:]
+		if num == 1 && typ == protowire.BytesType {
+			h, n := protowire.ConsumeBytes(m)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			for len(h) > 0 {
+				hnum, htyp, hn := protowire.ConsumeTag(h)
+				if hn < 0 {
+					return 0, protowire.ParseError(hn)
+				}
+				h = h[hn:]
+				if hnum == 3 && htyp == protowire.VarintType {
+					v, vn := protowire.ConsumeVarint(h)
+					if vn < 0 {
+						return 0, protowire.ParseError(vn)
+					}
+					return persistence.Revision(v), nil
+				}
+				hn = protowire.ConsumeFieldValue(hnum, htyp, h)
+				if hn < 0 {
+					return 0, protowire.ParseError(hn)
+				}
+				h = h[hn:]
+			}
+			return 0, fmt.Errorf("record header has no revision")
+		}
+		n = protowire.ConsumeFieldValue(num, typ, m)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		m = m[n:]
+	}
+	return 0, fmt.Errorf("record has no header")
 }
 
 // DecodeMessage decodes one record from its message bytes (the Span returned

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -61,13 +61,17 @@ func AppendRecords(buf []byte, first persistence.Revision, records []*persistenc
 	return AppendRecordsAt(buf, revisions, records)
 }
 
-// AppendRaw appends one already-encoded record (the bytes of a Span) to buf,
-// returning its Span relative to the start of buf. Compaction copies records
-// between files this way, without decoding them.
-func AppendRaw(buf []byte, m []byte) ([]byte, Span) {
-	buf = protowire.AppendVarint(buf, uint64(len(m)))
-	span := Span{Offset: len(buf), Length: len(m)}
-	return append(buf, m...), span
+// WriteRecord writes one already-encoded record to w with its length
+// prefix, as AppendRecords would, and returns the number of bytes written
+// (the record's Span starts len(m) bytes before the end of them).
+func WriteRecord(w io.Writer, m EncodedRecord) (int, error) {
+	prefix := protowire.AppendVarint(nil, uint64(len(m)))
+	n, err := w.Write(prefix)
+	if err != nil {
+		return n, err
+	}
+	k, err := w.Write(m)
+	return n + k, err
 }
 
 // AppendRecordsAt is AppendRecords with an explicit revision per record, for
@@ -125,6 +129,15 @@ type Span struct {
 	Length int
 }
 
+// Bytes returns the record the span locates in data.
+func (s Span) Bytes(data []byte) EncodedRecord {
+	return EncodedRecord(data[s.Offset : s.Offset+s.Length])
+}
+
+// EncodedRecord is one record as stored: the bytes of its WatchResponse
+// message, without the length prefix. It is what Span locates.
+type EncodedRecord []byte
+
 // Offsets returns the span and revision of every record in a file without
 // decoding the records: it reads the length prefixes and each record's
 // header. With a span, a record can be read from storage by itself (see
@@ -164,7 +177,7 @@ func Scan(data []byte) (spans []Span, revisions []persistence.Revision, complete
 			return spans, revisions, pos, nil
 		}
 		m := data[pos+k : pos+k+int(n)]
-		rev, err := recordRevision(m)
+		rev, err := EncodedRecord(m).Revision()
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("decoding record %d: %w", len(spans), err)
 		}
@@ -175,9 +188,9 @@ func Scan(data []byte) (spans []Span, revisions []persistence.Revision, complete
 	return spans, revisions, pos, nil
 }
 
-// recordRevision reads the revision from a record's header without decoding
-// the rest (WatchResponse field 1, ResponseHeader field 3).
-func recordRevision(m []byte) (persistence.Revision, error) {
+// Revision reads the record's revision from its header without decoding the
+// rest (WatchResponse field 1, ResponseHeader field 3).
+func (m EncodedRecord) Revision() (persistence.Revision, error) {
 	for len(m) > 0 {
 		num, typ, n := protowire.ConsumeTag(m)
 		if n < 0 {
@@ -219,9 +232,8 @@ func recordRevision(m []byte) (persistence.Revision, error) {
 	return 0, fmt.Errorf("record has no header")
 }
 
-// DecodeMessage decodes one record from its message bytes (the Span returned
-// by Offsets).
-func DecodeMessage(m []byte) (*persistence.LogRecord, error) {
+// Decode decodes the record.
+func (m EncodedRecord) Decode() (*persistence.LogRecord, error) {
 	wr := &etcdserverpb.WatchResponse{}
 	if err := proto.Unmarshal(m, wr); err != nil {
 		return nil, err
@@ -251,12 +263,12 @@ func Decode(data []byte) ([]*persistence.LogRecord, error) {
 	return records, nil
 }
 
-// DecodeMessageAlias is DecodeMessage without copying: the returned record's
-// keys and values alias m, so m must stay valid and unmodified for as long as
-// the record is in use (a read-only mapping of a closed log file is). It
-// parses exactly the fields of etcdserverpb.WatchResponse, mvccpb.Event and
+// DecodeAlias is Decode without copying: the returned record's keys and
+// values alias m, so m must stay valid and unmodified for as long as the
+// record is in use (a read-only mapping of a closed log file is). It parses
+// exactly the fields of etcdserverpb.WatchResponse, mvccpb.Event and
 // mvccpb.KeyValue that the log writes, and skips any others.
-func DecodeMessageAlias(m []byte) (*persistence.LogRecord, error) {
+func (m EncodedRecord) DecodeAlias() (*persistence.LogRecord, error) {
 	record := &persistence.LogRecord{}
 	for len(m) > 0 {
 		num, typ, n := protowire.ConsumeTag(m)

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -46,7 +46,7 @@ func batch(n int) []*persistence.LogRecord {
 
 func TestRoundTrip(t *testing.T) {
 	in := batch(50)
-	data, err := Encode(in)
+	data, err := Encode(1, in)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestRoundTrip(t *testing.T) {
 	if _, err := Decode([]byte(`{"Records":[]}`)); err == nil {
 		t.Error("decoded a JSON batch as valid")
 	}
-	if _, err := Decode(data[:len(data)-5]); err == nil {
+	if _, err := Decode(data[:len(data)-3]); err == nil {
 		t.Error("decoded a truncated batch as valid")
 	}
 	if out, err := Decode(data[:len(magic)]); err != nil || len(out) != 0 {
@@ -80,7 +80,7 @@ func TestRoundTrip(t *testing.T) {
 
 func TestDecodeRecord(t *testing.T) {
 	in := batch(50)
-	data, err := Encode(in)
+	data, err := Encode(1, in)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,23 +101,28 @@ func TestDecodeRecord(t *testing.T) {
 	if _, err := DecodeRecord(data, len(in)); err == nil {
 		t.Error("decoded a record past the end of the batch")
 	}
-	if _, err := DecodeRecord(data[:len(data)-5], len(in)-1); err == nil {
+	if _, err := DecodeRecord(data[:len(data)-3], len(in)-1); err == nil {
 		t.Error("decoded the last record of a truncated batch")
 	}
 }
 
 func TestOffsets(t *testing.T) {
 	in := batch(50)
-	data, err := Encode(in)
+	data, err := Encode(1, in)
 	if err != nil {
 		t.Fatal(err)
 	}
-	spans, err := Offsets(data)
+	spans, revisions, err := Offsets(data)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(spans) != len(in) {
 		t.Fatalf("%d spans, want %d", len(spans), len(in))
+	}
+	for i, r := range revisions {
+		if r != persistence.Revision(i+1) {
+			t.Fatalf("record %d has revision %d, want %d", i, r, i+1)
+		}
 	}
 	for i, sp := range spans {
 		got, err := DecodeMessage(data[sp.Offset : sp.Offset+sp.Length])
@@ -133,18 +138,27 @@ func TestOffsets(t *testing.T) {
 			}
 		}
 	}
-	if _, err := Offsets(data[:len(data)-5]); err == nil {
+	if _, _, err := Offsets(data[:len(data)-3]); err == nil {
 		t.Error("offsets of a truncated batch succeeded")
+	}
+
+	// A sparse file: explicit revisions survive a scan.
+	sparse, _, err := AppendRecordsAt(append([]byte(nil), Header()...), []persistence.Revision{3, 7, 500}, in[:3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, revs, err := Offsets(sparse); err != nil || fmt.Sprint(revs) != "[3 7 500]" {
+		t.Fatalf("sparse revisions = %v, %v", revs, err)
 	}
 }
 
 func TestDecodeMessageAlias(t *testing.T) {
 	in := batch(50)
-	data, err := Encode(in)
+	data, err := Encode(1, in)
 	if err != nil {
 		t.Fatal(err)
 	}
-	spans, err := Offsets(data)
+	spans, _, err := Offsets(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,8 +189,8 @@ func TestDecodeMessageAlias(t *testing.T) {
 }
 
 func BenchmarkDecodeMessageAlias(b *testing.B) {
-	data, _ := Encode(batch(500))
-	spans, _ := Offsets(data)
+	data, _ := Encode(1, batch(500))
+	spans, _, _ := Offsets(data)
 	sp := spans[250]
 	m := data[sp.Offset : sp.Offset+sp.Length]
 	b.ReportAllocs()
@@ -188,8 +202,8 @@ func BenchmarkDecodeMessageAlias(b *testing.B) {
 }
 
 func BenchmarkDecodeMessage(b *testing.B) {
-	data, _ := Encode(batch(500))
-	spans, _ := Offsets(data)
+	data, _ := Encode(1, batch(500))
+	spans, _, _ := Offsets(data)
 	sp := spans[250]
 	m := data[sp.Offset : sp.Offset+sp.Length]
 	b.ReportAllocs()
@@ -201,7 +215,7 @@ func BenchmarkDecodeMessage(b *testing.B) {
 }
 
 func BenchmarkDecodeRecord(b *testing.B) {
-	data, _ := Encode(batch(500))
+	data, _ := Encode(1, batch(500))
 	for i := 0; i < b.N; i++ {
 		if _, err := DecodeRecord(data, 250); err != nil {
 			b.Fatal(err)
@@ -212,14 +226,14 @@ func BenchmarkDecodeRecord(b *testing.B) {
 func BenchmarkEncode(b *testing.B) {
 	records := batch(500)
 	for i := 0; i < b.N; i++ {
-		if _, err := Encode(records); err != nil {
+		if _, err := Encode(1, records); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
 func BenchmarkDecode(b *testing.B) {
-	data, _ := Encode(batch(500))
+	data, _ := Encode(1, batch(500))
 	b.SetBytes(int64(len(data)))
 	for i := 0; i < b.N; i++ {
 		if _, err := Decode(data); err != nil {

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -125,7 +125,7 @@ func TestOffsets(t *testing.T) {
 		}
 	}
 	for i, sp := range spans {
-		got, err := DecodeMessage(data[sp.Offset : sp.Offset+sp.Length])
+		got, err := sp.Bytes(data).Decode()
 		if err != nil {
 			t.Fatalf("record %d: %v", i, err)
 		}
@@ -164,11 +164,11 @@ func TestDecodeMessageAlias(t *testing.T) {
 	}
 	for i, sp := range spans {
 		m := data[sp.Offset : sp.Offset+sp.Length]
-		got, err := DecodeMessageAlias(m)
+		got, err := EncodedRecord(m).DecodeAlias()
 		if err != nil {
 			t.Fatalf("record %d: %v", i, err)
 		}
-		want, _ := DecodeMessage(m)
+		want, _ := EncodedRecord(m).Decode()
 		if len(got.Events) != len(want.Events) {
 			t.Fatalf("record %d: %d events, want %d", i, len(got.Events), len(want.Events))
 		}
@@ -195,7 +195,7 @@ func BenchmarkDecodeMessageAlias(b *testing.B) {
 	m := data[sp.Offset : sp.Offset+sp.Length]
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := DecodeMessageAlias(m); err != nil {
+		if _, err := EncodedRecord(m).DecodeAlias(); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -208,7 +208,7 @@ func BenchmarkDecodeMessage(b *testing.B) {
 	m := data[sp.Offset : sp.Offset+sp.Length]
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := DecodeMessage(m); err != nil {
+		if _, err := EncodedRecord(m).Decode(); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -17,6 +17,7 @@ package memorystorage
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -270,5 +271,93 @@ func TestStorageCompact(t *testing.T) {
 	list, _ := store2.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/"), RangeEnd: []byte("/k0")})
 	if len(list.Kvs) != 5 {
 		t.Fatalf("after reopen, list has %d keys, want 5", len(list.Kvs))
+	}
+}
+
+// TestCompactKeepsStateAtPoint checks that reads at the compaction point see
+// the same state after the log is compacted as before. Two histories matter:
+// a key written again above the point (its write at the point must survive,
+// though it is no longer the key's latest), and a key deleted below the
+// point and recreated above it (the delete must survive, so that the key
+// reads as absent at the point rather than failing).
+func TestCompactKeepsStateAtPoint(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	open := func() *MemoryStorage {
+		t.Helper()
+		lg, err := filesystemlog.NewFilesystemLogWithOptions(dir, filesystemlog.Options{RotateBytes: 2000, CacheBytes: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		store, err := NewMemoryStorage(lg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return store
+	}
+	store := open()
+
+	var point Revision
+	for round := 0; round < 12; round++ {
+		for k := 0; k < 10; k++ {
+			key := []byte(fmt.Sprintf("/k/%02d", k))
+			if k%3 == 0 && round >= 4 && round < 8 {
+				// Deleted in round 4, absent through round 7, recreated in
+				// round 8.
+				if round == 4 {
+					if _, err := store.Delete(ctx, &etcdserverpb.DeleteRangeRequest{Key: key}); err != nil {
+						t.Fatal(err)
+					}
+				}
+				continue
+			}
+			if _, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: key, Value: []byte(fmt.Sprintf("v%d", round))}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if round == 6 {
+			point, _ = store.GetCurrentRevision(ctx)
+		}
+	}
+
+	snapshot := func(store *MemoryStorage, at Revision) string {
+		t.Helper()
+		list, err := store.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/"), RangeEnd: []byte("/k0"), Revision: int64(at)})
+		if err != nil {
+			t.Fatalf("list at %d: %v", at, err)
+		}
+		var s []string
+		for _, kv := range list.Kvs {
+			s = append(s, fmt.Sprintf("%s=%s@%d", kv.Key, kv.Value, kv.ModRevision))
+		}
+		return fmt.Sprint(s)
+	}
+	head, _ := store.GetCurrentRevision(ctx)
+	atPoint, atHead := snapshot(store, point), snapshot(store, head)
+	if !strings.Contains(atPoint, "/k/01=v6@") || strings.Contains(atPoint, "/k/00=") {
+		t.Fatalf("unexpected state at the point: %s", atPoint)
+	}
+
+	if compacted, err := store.Compact(ctx, point); err != nil || compacted != point {
+		t.Fatalf("Compact = %d, %v; want %d", compacted, err, point)
+	}
+	store.WaitForCompaction()
+	if got := snapshot(store, point); got != atPoint {
+		t.Fatalf("state at the compaction point changed:\n before %s\n after  %s", atPoint, got)
+	}
+	if got := snapshot(store, head); got != atHead {
+		t.Fatalf("state at head changed:\n before %s\n after  %s", atHead, got)
+	}
+
+	// The compacted files are what a restart rebuilds from.
+	store.GracefulStop()
+	store.log.Close()
+	store = open()
+	defer store.log.Close()
+	if got := snapshot(store, point); got != atPoint {
+		t.Fatalf("state at the compaction point after restart:\n before %s\n after  %s", atPoint, got)
+	}
+	if got := snapshot(store, head); got != atHead {
+		t.Fatalf("state at head after restart:\n before %s\n after  %s", atHead, got)
 	}
 }

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 
+	"justinsb.com/cloudetcd/pkg/persistence/filesystemlog"
 	"justinsb.com/cloudetcd/pkg/persistence/memorylog"
 )
 
@@ -183,5 +184,91 @@ func TestConcurrentWritesToDistinctKeys(t *testing.T) {
 		if kv.Version != 2 || string(kv.Value) != "b" {
 			t.Errorf("%s: version %d value %q", kv.Key, kv.Version, kv.Value)
 		}
+	}
+}
+
+// TestStorageCompact drives compaction through the storage: overwritten and
+// deleted keys, an open watcher that must not be cut off, then the log is
+// reopened and the state is what it was.
+func TestStorageCompact(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	newStore := func() *MemoryStorage {
+		t.Helper()
+		lg, err := filesystemlog.NewFilesystemLogWithOptions(dir, filesystemlog.Options{RotateBytes: 4000, CacheBytes: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		store, err := NewMemoryStorage(lg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return store
+	}
+	store := newStore()
+
+	for round := 0; round < 20; round++ {
+		for k := 0; k < 10; k++ {
+			key := fmt.Sprintf("/k/%02d", k)
+			if _, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: []byte(key), Value: []byte(fmt.Sprintf("v%d", round))}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	for k := 0; k < 10; k += 2 {
+		if _, err := store.Delete(ctx, &etcdserverpb.DeleteRangeRequest{Key: []byte(fmt.Sprintf("/k/%02d", k))}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A watcher that has delivered up to some revision holds the compaction
+	// floor at that revision.
+	watchFrom, _ := store.GetCurrentRevision(ctx)
+	head := watchFrom
+	compactedTo, err := store.Compact(ctx, head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compactedTo != head {
+		t.Fatalf("compacted to %d, want %d", compactedTo, head)
+	}
+
+	expect := func(store *MemoryStorage) {
+		t.Helper()
+		list, err := store.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/"), RangeEnd: []byte("/k0")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list.Kvs) != 5 {
+			t.Fatalf("list has %d keys, want 5 (odd ones)", len(list.Kvs))
+		}
+		for _, kv := range list.Kvs {
+			if string(kv.Value) != "v19" || kv.Version != 20 {
+				t.Fatalf("%s = %s (version %d), want v19 (version 20)", kv.Key, kv.Value, kv.Version)
+			}
+		}
+		for k := 0; k < 10; k += 2 {
+			resp, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte(fmt.Sprintf("/k/%02d", k))})
+			if err != nil || len(resp.Kvs) != 0 {
+				t.Fatalf("deleted key %02d: %v %v", k, resp.GetKvs(), err)
+			}
+		}
+	}
+	expect(store)
+	store.WaitForCompaction()
+	if _, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: []byte("/k/01"), Value: []byte("after")}); err != nil {
+		t.Fatal(err)
+	}
+	store.GracefulStop()
+	store.log.Close()
+
+	store2 := newStore()
+	defer store2.log.Close()
+	resp, err := store2.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/01")})
+	if err != nil || len(resp.Kvs) != 1 || string(resp.Kvs[0].Value) != "after" || resp.Kvs[0].Version != 21 {
+		t.Fatalf("after reopen, /k/01 = %v (%v)", resp.GetKvs(), err)
+	}
+	list, _ := store2.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/"), RangeEnd: []byte("/k0")})
+	if len(list.Kvs) != 5 {
+		t.Fatalf("after reopen, list has %d keys, want 5", len(list.Kvs))
 	}
 }

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -38,6 +39,10 @@ type MemoryStorage struct {
 	mu sync.RWMutex
 
 	revisions bptree.BPTree
+
+	// compacted is the revision history has been discarded through.
+	compacted Revision
+	compactWG sync.WaitGroup
 
 	// applied is the highest log revision whose events have been applied to
 	// revisions (and the lease manager). Records are committed by the log's
@@ -116,7 +121,7 @@ func (m *MemoryStorage) ReplayLog(ctx context.Context) error {
 
 			case mvccpb.DELETE:
 				// Replay DELETE operation
-				m.revisions.AddRevision(event.Kv.Key, revision)
+				m.revisions.AddTombstone(event.Kv.Key, revision)
 
 			default:
 				// Skip unknown operations
@@ -162,8 +167,10 @@ func (m *MemoryStorage) applyUpTo(ctx context.Context, rev Revision) error {
 		}
 		for _, event := range record.Events {
 			switch event.Type {
-			case mvccpb.PUT, mvccpb.DELETE:
+			case mvccpb.PUT:
 				m.revisions.AddRevision(event.Kv.Key, r)
+			case mvccpb.DELETE:
+				m.revisions.AddTombstone(event.Kv.Key, r)
 			default:
 				klog.Fatalf("unknown operation: %s", event.Type)
 			}
@@ -967,6 +974,67 @@ func createHeader(revision Revision) *etcdserverpb.ResponseHeader {
 		Revision:  int64(revision),
 		RaftTerm:  1, // Simple term
 	}
+}
+
+// Compact discards history at or below revision. The revision is lowered if
+// an open watcher has not yet delivered past it, so that watchers are not
+// cut off; it is then applied to the index (each key keeps its latest
+// version at or below the point, and deleted keys go) and to the log (files
+// below the point are rewritten with only the live records).
+func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revision, error) {
+	m.mu.Lock()
+	through := revision
+	if through > m.applied {
+		through = m.applied
+	}
+	m.watcherMu.RLock()
+	for _, w := range m.watchers {
+		w.stateMutex.Lock()
+		closed := w.closed
+		w.stateMutex.Unlock()
+		if closed {
+			continue
+		}
+		if delivered := Revision(w.delivered.Load()); delivered < through {
+			through = delivered
+		}
+	}
+	m.watcherMu.RUnlock()
+	if through <= m.compacted {
+		m.mu.Unlock()
+		return m.compacted, nil
+	}
+	keysRemoved, revisionsDropped := m.revisions.Compact(through)
+	m.compacted = through
+	m.mu.Unlock()
+	klog.V(1).Infof("compacted index through revision %d: %d keys removed, %d revisions dropped", through, keysRemoved, revisionsDropped)
+
+	// The log rewrite runs in the background: it reads closed files and
+	// takes seconds at scale, and nothing waits on it. The log serializes
+	// compactions, so overlapping requests queue.
+	live := func(key []byte, rev Revision) bool {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		latest, ok := m.revisions.GetLatestRevisionByKey(key, storage.MAX_REVISION)
+		return ok && latest == rev
+	}
+	m.compactWG.Add(1)
+	go func() {
+		defer m.compactWG.Done()
+		start := time.Now()
+		if err := m.log.Compact(context.Background(), through, live); err != nil {
+			klog.Errorf("compacting log through revision %d: %v", through, err)
+			return
+		}
+		klog.V(1).Infof("compacted log through revision %d in %s", through, time.Since(start).Round(time.Millisecond))
+	}()
+	return through, nil
+}
+
+// WaitForCompaction blocks until background log compactions have finished,
+// for tests.
+func (m *MemoryStorage) WaitForCompaction() {
+	m.compactWG.Wait()
 }
 
 // GracefulStop stops the storage gracefully.

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -117,11 +117,11 @@ func (m *MemoryStorage) ReplayLog(ctx context.Context) error {
 			switch event.Type {
 			case mvccpb.PUT:
 				// Replay PUT operation
-				m.revisions.AddRevision(event.Kv.Key, revision)
+				m.revisions.AddRevision(event.Kv.Key, revision, false)
 
 			case mvccpb.DELETE:
 				// Replay DELETE operation
-				m.revisions.AddTombstone(event.Kv.Key, revision)
+				m.revisions.AddRevision(event.Kv.Key, revision, true)
 
 			default:
 				// Skip unknown operations
@@ -168,9 +168,9 @@ func (m *MemoryStorage) applyUpTo(ctx context.Context, rev Revision) error {
 		for _, event := range record.Events {
 			switch event.Type {
 			case mvccpb.PUT:
-				m.revisions.AddRevision(event.Kv.Key, r)
+				m.revisions.AddRevision(event.Kv.Key, r, false)
 			case mvccpb.DELETE:
-				m.revisions.AddTombstone(event.Kv.Key, r)
+				m.revisions.AddRevision(event.Kv.Key, r, true)
 			default:
 				klog.Fatalf("unknown operation: %s", event.Type)
 			}
@@ -979,8 +979,9 @@ func createHeader(revision Revision) *etcdserverpb.ResponseHeader {
 // Compact discards history at or below revision. The revision is lowered if
 // an open watcher has not yet delivered past it, so that watchers are not
 // cut off; it is then applied to the index (each key keeps its latest
-// version at or below the point, and deleted keys go) and to the log (files
-// below the point are rewritten with only the live records).
+// write at or below the point, and keys whose latest write is a delete go)
+// and to the log (files below the point are rewritten with only the
+// records the index still refers to).
 func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revision, error) {
 	m.mu.Lock()
 	through := revision
@@ -1012,10 +1013,14 @@ func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revisio
 	// The log rewrite runs in the background: it reads closed files and
 	// takes seconds at scale, and nothing waits on it. The log serializes
 	// compactions, so overlapping requests queue.
+	// A record is live if it is a key's state as of the compaction point:
+	// its latest put or delete at or below through, which is what the index
+	// kept. Not simply the key's latest revision: a read at a revision
+	// between the point and a later write of the key still needs it.
 	live := func(key []byte, rev Revision) bool {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		latest, ok := m.revisions.GetLatestRevisionByKey(key, storage.MAX_REVISION)
+		latest, ok := m.revisions.GetLatestRevisionByKey(key, through)
 		return ok && latest == rev
 	}
 	m.compactWG.Add(1)

--- a/pkg/storage/memorystorage/storage_test.go
+++ b/pkg/storage/memorystorage/storage_test.go
@@ -15,8 +15,6 @@
 package memorystorage
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -483,18 +481,10 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		// Run the watcher, joining the goroutine before the subtest returns:
-		// otherwise Run can lose the teardown race between watcher.Close and
-		// the cancellation of the parent test's context, return
-		// context.Canceled, and log to t after the subtest has completed,
-		// which panics the test binary.
-		runDone := make(chan error, 1)
+		defer watcher.Close()
+
 		go func() {
-			runDone <- watcher.Run(ctx)
-		}()
-		defer func() {
-			watcher.Close()
-			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
+			if err := watcher.Run(ctx); err != nil {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()
@@ -589,18 +579,10 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		// Run the watcher, joining the goroutine before the subtest returns:
-		// otherwise Run can lose the teardown race between watcher.Close and
-		// the cancellation of the parent test's context, return
-		// context.Canceled, and log to t after the subtest has completed,
-		// which panics the test binary.
-		runDone := make(chan error, 1)
+		defer watcher.Close()
+
 		go func() {
-			runDone <- watcher.Run(ctx)
-		}()
-		defer func() {
-			watcher.Close()
-			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
+			if err := watcher.Run(ctx); err != nil {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -80,6 +80,12 @@ type Storage interface {
 	// Txn executes a transaction against the storage.
 	Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error)
 
+	// Compact discards history at or below revision, as etcd's Compact does:
+	// reads at older revisions fail, the latest version of every key is
+	// kept. It returns the revision actually compacted to, which may be
+	// lower to keep open watchers readable.
+	Compact(ctx context.Context, revision Revision) (Revision, error)
+
 	// GracefulStop stops the storage gracefully.
 	GracefulStop()
 

--- a/pkg/workload/inprocess/inprocess.go
+++ b/pkg/workload/inprocess/inprocess.go
@@ -25,6 +25,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"justinsb.com/cloudetcd/pkg/api"
+	"justinsb.com/cloudetcd/pkg/persistence/filesystemlog"
 	"justinsb.com/cloudetcd/pkg/persistence/logfactory"
 	"justinsb.com/cloudetcd/pkg/storage/memorystorage"
 )
@@ -35,6 +36,8 @@ type Server struct {
 	Addr string
 	// Store is the server's storage, for diagnostics.
 	Store *memorystorage.MemoryStorage
+	// LogDir is the log's directory, for measuring what it uses on disk.
+	LogDir string
 
 	server *api.Server
 	cancel context.CancelFunc
@@ -64,6 +67,7 @@ func Start(ctx context.Context, logURI string, opts ...api.Option) (*Server, err
 	s := &Server{
 		Addr:   addr,
 		Store:  store,
+		LogDir: lg.(*filesystemlog.FilesystemLog).Dir(),
 		server: api.NewServer(store, opts...),
 		cancel: cancel,
 		done:   make(chan error, 1),

--- a/pkg/workload/report.go
+++ b/pkg/workload/report.go
@@ -55,6 +55,9 @@ type Report struct {
 	// HeapInuseBytes is the Go heap in use at the end of the phase, for
 	// the process running the report (the server too, when in-process).
 	HeapInuseBytes uint64 `json:"heapInuseBytes"`
+	// LogBytes is what the log uses on disk at the end of the phase
+	// (in-process servers only).
+	LogBytes int64 `json:"logBytes,omitempty"`
 }
 
 // OpReport summarizes one op label.
@@ -155,6 +158,9 @@ func (r *Runner) report(phase string, stats *Stats, expected map[string]float64)
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	rep.HeapInuseBytes = mem.HeapInuse
+	if r.LogBytes != nil {
+		rep.LogBytes = r.LogBytes()
+	}
 	if len(stats.errs) > 0 {
 		rep.ErrorSamples = map[string]int64{}
 		for msg, n := range stats.errs {
@@ -167,8 +173,12 @@ func (r *Runner) report(phase string, stats *Stats, expected map[string]float64)
 // Text renders the report as a table.
 func (r *Report) Text() string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "== %s: %d nodes, %d pods (%d keys), %s, %d ops (%.0f/s), %d errors, heap %.0f MB\n",
+	fmt.Fprintf(&sb, "== %s: %d nodes, %d pods (%d keys), %s, %d ops (%.0f/s), %d errors, heap %.0f MB",
 		r.Phase, r.Nodes, r.Pods, r.Keys, r.Duration.Round(time.Millisecond), r.TotalOps, r.TotalRate, r.Errors, float64(r.HeapInuseBytes)/(1<<20))
+	if r.LogBytes > 0 {
+		fmt.Fprintf(&sb, ", log %.0f MB on disk", float64(r.LogBytes)/(1<<20))
+	}
+	sb.WriteString("\n")
 	tw := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "op\tcount\terrors\tconflicts\trate/s\texpected/s\tp50\tp90\tp99\tp99.9\tmax")
 	labels := make([]string, 0, len(r.Ops))

--- a/pkg/workload/runner.go
+++ b/pkg/workload/runner.go
@@ -49,6 +49,9 @@ type Runner struct {
 	// samples it to report how far behind the log head the server-side
 	// watchers get, separately from what the client receives.
 	WatcherStatus func() []storage.WatcherStatus
+	// LogBytes, if set, reports what the log uses on disk; reported per
+	// phase.
+	LogBytes func() int64
 
 	exec   *executor
 	state  *stateMap


### PR DESCRIPTION
## Summary

**Stacked on #55** (→ #53), and this branch also **merges #54** (it needs the watcher positions for the compaction floor), so its diff shows #54's changes until #54 lands on `main`.

Compaction as discussed — per file, not one world snapshot:

- **`Compact` RPC is real.** History at or below the requested revision is discarded while the latest version of every key is kept (etcd's semantics). The point is lowered to the oldest open watcher's delivered position so watchers aren't cut off. The index prune is synchronous (36 ms at 100k nodes); the file rewrite runs in the background.
- **Index**: tombstones are recorded; each key keeps its revisions above the point plus the latest at or below; keys deleted at or below the point are removed. This bounds the per-key revision lists — the biggest unbounded *heap* growth (8,640 revisions/day per node lease).
- **Log**: every record now carries its revision in its header, so files may be sparse. Closed files at or below the point are rewritten with only their live records (a put that is still its key's latest; deletes and superseded puts go), record bytes copied as-is via the mapping, grouped by *live* size to stay under `RotateBytes`, skipping compacted files that are still >90% live. Compacted files are named `<first>-<last>.log`; reads of dropped revisions return `ErrCompacted`. Originals are removed locally and from the archive once the replacement is durable; a restart that finds both keeps the compacted one.
- **mmap interplay**: mappings of removed files are unmapped after a one-minute grace period (records decoded from them alias their bytes), and mapped reads are no longer put in the record cache for the same reason.
- Bench reports `log … MB on disk` per phase.

## Result (100k nodes, 10k writes/s, 3 minutes, `rotateBytes=16MB`; live set ≈ 1.3 GB with `kube` blobs)

| | compact every 10 s | never |
|---|---|---|
| log on disk | **2,163 MB, settled** | 4,556 MB, +1.1 GB/min |
| heap | 278 MB | 327 MB |
| `Compact` RPC latency | 36 ms | — |
| writes/s, p50 | 9,994, 26.9 ms | 9,993, 24.4 ms |

Not in this PR (next, per the plan): `ErrCompacted` from `Range`/`Watch` at revisions below the point, and lease persistence.

## Test plan

- [x] `bptree.TestCompact`; codec: per-record revisions, sparse files, torn-tail scan
- [x] `TestCompaction` (file log): overwrites+deletes across many files → bytes drop >3×, files merge, every live revision reads, dropped ones → `ErrCompacted`, reopen has identical state and continues, second compaction is a no-op
- [x] `TestStorageCompact`: through the storage, with tombstones and reopen
- [x] `TestCompactionReplacesArchivedFiles`: compacted file uploaded, originals deleted from the archive, fresh directory restores from it
- [x] `go test -race ./pkg/persistence/... ./pkg/storage/memorystorage ./pkg/api ./pkg/workload`; `RUN_E2E=1` kube-apiserver smoke (its compactor now hits a real `Compact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek
