### PR TITLE
filesystemlog: memory-map closed files and decode records by aliasing

### DIFF
--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -104,6 +104,9 @@ type logFile struct {
 	// logcodec.DecodeMessageAlias), so old records live in the page cache
 	// rather than on the heap.
 	mapped []byte
+	// reader is the file opened for positioned reads (the active file, or
+	// any file where mapping is unavailable), opened on first read and kept.
+	reader *os.File
 }
 
 func (f *logFile) last() Revision { return f.first + Revision(f.count) - 1 }
@@ -575,11 +578,10 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 			return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
 		}
 		span := spans[pos]
-		file, err := os.Open(filepath.Join(l.dir, f.name))
+		file, err := l.reader(f)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open log file %s: %w", f.name, err)
+			return nil, err
 		}
-		defer file.Close()
 		buf := make([]byte, span.Length)
 		if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
 			return nil, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
@@ -594,7 +596,10 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 }
 
 // mapping returns the memory mapping of a closed file, creating it on first
-// use, or nil if the file is active (still growing) or cannot be mapped.
+// use, or nil if the file is active (still growing) or the platform has no
+// memory mapping. A mapping that fails where it should work is fatal: the
+// fallback would be a positioned read per record, a large and silent change
+// in how the server performs.
 func (l *FilesystemLog) mapping(f *logFile, closed bool) []byte {
 	if !closed {
 		return nil
@@ -603,13 +608,30 @@ func (l *FilesystemLog) mapping(f *logFile, closed bool) []byte {
 	defer l.mapMu.Unlock()
 	if f.mapped == nil {
 		m, err := mapFile(filepath.Join(l.dir, f.name), f.size)
-		if err != nil {
-			klog.V(2).Infof("not mapping log file %s (%v); reading it instead", f.name, err)
+		if errors.Is(err, errNoMmap) {
 			return nil
+		}
+		if err != nil {
+			panic(fmt.Sprintf("memory-mapping log file %s (%d bytes): %v", f.name, f.size, err))
 		}
 		f.mapped = m
 	}
 	return f.mapped
+}
+
+// reader returns a file's handle for positioned reads, opening it on first
+// use and keeping it open.
+func (l *FilesystemLog) reader(f *logFile) (*os.File, error) {
+	l.mapMu.Lock()
+	defer l.mapMu.Unlock()
+	if f.reader == nil {
+		file, err := os.Open(filepath.Join(l.dir, f.name))
+		if err != nil {
+			return nil, fmt.Errorf("failed to open log file %s: %w", f.name, err)
+		}
+		f.reader = file
+	}
+	return f.reader, nil
 }
 
 // fileSpansFrom is fileSpans for a file whose bytes are already at hand.
@@ -741,6 +763,12 @@ func (l *FilesystemLog) Close() error {
 			err = uerr
 		}
 		f.mapped = nil
+		if f.reader != nil {
+			if cerr := f.reader.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
+			f.reader = nil
+		}
 	}
 	l.mapMu.Unlock()
 

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -99,6 +99,11 @@ type logFile struct {
 	opened time.Time
 	// archived is whether the archive holds this (closed) file.
 	archived bool
+	// mapped is the read-only memory mapping of a closed file, made on first
+	// read; records read from it alias its bytes (see
+	// logcodec.DecodeMessageAlias), so old records live in the page cache
+	// rather than on the heap.
+	mapped []byte
 }
 
 func (f *logFile) last() Revision { return f.first + Revision(f.count) - 1 }
@@ -130,6 +135,9 @@ type FilesystemLog struct {
 
 	// cache holds recently written and read records.
 	cache *recordcache.Cache
+
+	// mapMu serializes creating mappings.
+	mapMu sync.Mutex
 
 	// uploads carries closed files to the uploader goroutine.
 	uploads      chan string
@@ -533,36 +541,93 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 
 	l.mu.RLock()
 	f, ok := l.findFile(revision)
+	closed := ok && f != l.files[len(l.files)-1]
 	l.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("log entry for revision %d not found in any file", revision)
 	}
-	spans, err := l.fileSpans(f)
-	if err != nil {
-		return nil, err
-	}
 	pos := int(revision - f.first)
-	if pos < 0 || pos >= len(spans) {
-		return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
-	}
 
-	// One positioned read of exactly this record's bytes.
-	span := spans[pos]
-	file, err := os.Open(filepath.Join(l.dir, f.name))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open log file %s: %w", f.name, err)
-	}
-	defer file.Close()
-	buf := make([]byte, span.Length)
-	if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
-		return nil, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
-	}
-	record, err := logcodec.DecodeMessage(buf)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, f.name, err)
+	var record *LogRecord
+	if m := l.mapping(f, closed); m != nil {
+		// A closed file: decode straight out of its mapping, aliasing the
+		// key and value bytes rather than copying them.
+		spans, err := l.fileSpansFrom(f, m)
+		if err != nil {
+			return nil, err
+		}
+		if pos < 0 || pos >= len(spans) {
+			return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+		}
+		span := spans[pos]
+		record, err = logcodec.DecodeMessageAlias(m[span.Offset : span.Offset+span.Length])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, f.name, err)
+		}
+	} else {
+		// The active file (or a platform without mmap): one positioned read
+		// of exactly this record's bytes.
+		spans, err := l.fileSpans(f)
+		if err != nil {
+			return nil, err
+		}
+		if pos < 0 || pos >= len(spans) {
+			return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+		}
+		span := spans[pos]
+		file, err := os.Open(filepath.Join(l.dir, f.name))
+		if err != nil {
+			return nil, fmt.Errorf("failed to open log file %s: %w", f.name, err)
+		}
+		defer file.Close()
+		buf := make([]byte, span.Length)
+		if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
+			return nil, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
+		}
+		record, err = logcodec.DecodeMessage(buf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, f.name, err)
+		}
 	}
 	l.cache.Put(revision, record)
 	return record, nil
+}
+
+// mapping returns the memory mapping of a closed file, creating it on first
+// use, or nil if the file is active (still growing) or cannot be mapped.
+func (l *FilesystemLog) mapping(f *logFile, closed bool) []byte {
+	if !closed {
+		return nil
+	}
+	l.mapMu.Lock()
+	defer l.mapMu.Unlock()
+	if f.mapped == nil {
+		m, err := mapFile(filepath.Join(l.dir, f.name), f.size)
+		if err != nil {
+			klog.V(2).Infof("not mapping log file %s (%v); reading it instead", f.name, err)
+			return nil
+		}
+		f.mapped = m
+	}
+	return f.mapped
+}
+
+// fileSpansFrom is fileSpans for a file whose bytes are already at hand.
+func (l *FilesystemLog) fileSpansFrom(f *logFile, data []byte) ([]logcodec.Span, error) {
+	l.spansMu.Lock()
+	spans, ok := l.spans[f.first]
+	l.spansMu.Unlock()
+	if ok {
+		return spans, nil
+	}
+	spans, err := logcodec.Offsets(data)
+	if err != nil {
+		return nil, fmt.Errorf("indexing log file %s: %w", f.name, err)
+	}
+	l.spansMu.Lock()
+	l.spans[f.first] = spans
+	l.spansMu.Unlock()
+	return spans, nil
 }
 
 // fileSpans returns the record spans of a file, scanning its length
@@ -669,6 +734,15 @@ func (l *FilesystemLog) Close() error {
 	case <-time.After(30 * time.Second):
 		klog.Warningf("log closed with uploads still pending; they will resume on the next start")
 	}
+
+	l.mapMu.Lock()
+	for _, f := range l.files {
+		if uerr := unmapFile(f.mapped); uerr != nil && err == nil {
+			err = uerr
+		}
+		f.mapped = nil
+	}
+	l.mapMu.Unlock()
 
 	if l.removeOnClose {
 		if rerr := os.RemoveAll(l.dir); err == nil {

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -541,82 +541,102 @@ func (l *FilesystemLog) GetLogEntry(revision Revision) (*LogRecord, error) {
 	if record, ok := l.cache.Get(revision); ok {
 		return record, nil
 	}
-
-	l.mu.RLock()
-	f, ok := l.findFile(revision)
-	closed := ok && f != l.files[len(l.files)-1]
-	l.mu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("log entry for revision %d not found in any file", revision)
+	m, aliased, err := l.recordBytes(revision)
+	if err != nil {
+		return nil, err
 	}
-	pos := int(revision - f.first)
-
-	var record *LogRecord
-	if m := l.mapping(f, closed); m != nil {
-		// A closed file: decode straight out of its mapping, aliasing the
-		// key and value bytes rather than copying them.
-		spans, err := l.fileSpansFrom(f, m)
+	if aliased {
+		// Decode in place, aliasing the key and value bytes rather than
+		// copying them. Not cached: the cache is for the write-recent set,
+		// and a cached alias would pin the mapping.
+		record, err := logcodec.DecodeMessageAlias(m)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to decode log record %d: %w", revision, err)
 		}
-		if pos < 0 || pos >= len(spans) {
-			return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
-		}
-		span := spans[pos]
-		record, err = logcodec.DecodeMessageAlias(m[span.Offset : span.Offset+span.Length])
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, f.name, err)
-		}
-	} else {
-		// The active file (or a platform without mmap): one positioned read
-		// of exactly this record's bytes.
-		spans, err := l.fileSpans(f)
-		if err != nil {
-			return nil, err
-		}
-		if pos < 0 || pos >= len(spans) {
-			return nil, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
-		}
-		span := spans[pos]
-		file, err := l.reader(f)
-		if err != nil {
-			return nil, err
-		}
-		buf := make([]byte, span.Length)
-		if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
-			return nil, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
-		}
-		record, err = logcodec.DecodeMessage(buf)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode log record %d from file %s: %w", revision, f.name, err)
-		}
+		return record, nil
+	}
+	record, err := logcodec.DecodeMessage(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode log record %d: %w", revision, err)
 	}
 	l.cache.Put(revision, record)
 	return record, nil
 }
 
-// mapping returns the memory mapping of a closed file, creating it on first
-// use, or nil if the file is active (still growing) or the platform has no
-// memory mapping. A mapping that fails where it should work is fatal: the
-// fallback would be a positioned read per record, a large and silent change
-// in how the server performs.
-func (l *FilesystemLog) mapping(f *logFile, closed bool) []byte {
-	if !closed {
-		return nil
+// recordBytes returns the encoded bytes of revision's record. For a closed
+// file they alias its memory mapping (aliased is true) and must not be
+// retained; for the active file, or where mapping is unavailable, they are
+// one positioned read into a fresh buffer.
+func (l *FilesystemLog) recordBytes(revision Revision) (m []byte, aliased bool, err error) {
+	l.mu.RLock()
+	f, ok := l.findFile(revision)
+	active := ok && f == l.files[len(l.files)-1]
+	l.mu.RUnlock()
+	if !ok {
+		return nil, false, fmt.Errorf("log entry for revision %d not found in any file", revision)
 	}
+	pos := int(revision - f.first)
+
+	if !active {
+		m, err := l.mapping(f)
+		if err != nil {
+			return nil, false, err
+		}
+		if m != nil {
+			spans, err := l.fileSpansFrom(f, m)
+			if err != nil {
+				return nil, false, err
+			}
+			if pos < 0 || pos >= len(spans) {
+				return nil, false, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+			}
+			span := spans[pos]
+			return m[span.Offset : span.Offset+span.Length], true, nil
+		}
+	}
+
+	spans, err := l.fileSpans(f)
+	if err != nil {
+		return nil, false, err
+	}
+	if pos < 0 || pos >= len(spans) {
+		return nil, false, fmt.Errorf("log entry for revision %d not found in file %s (%d records)", revision, f.name, len(spans))
+	}
+	span := spans[pos]
+	file, err := l.reader(f)
+	if err != nil {
+		return nil, false, err
+	}
+	buf := make([]byte, span.Length)
+	if _, err := file.ReadAt(buf, int64(span.Offset)); err != nil {
+		return nil, false, fmt.Errorf("failed to read record %d from log file %s: %w", revision, f.name, err)
+	}
+	return buf, false, nil
+}
+
+// mapping returns a closed file's memory mapping, creating it on first use
+// from the file's read handle, or nil where the platform has no memory
+// mapping. A mapping that fails where it should work is fatal: the
+// alternative would be a positioned read per record, a large and silent
+// change in how the server performs.
+func (l *FilesystemLog) mapping(f *logFile) ([]byte, error) {
 	l.mapMu.Lock()
 	defer l.mapMu.Unlock()
 	if f.mapped == nil {
-		m, err := mapFile(filepath.Join(l.dir, f.name), f.size)
+		file, err := l.readerLocked(f)
+		if err != nil {
+			return nil, err
+		}
+		m, err := mmapFile(file, f.size)
 		if errors.Is(err, errNoMmap) {
-			return nil
+			return nil, nil
 		}
 		if err != nil {
 			panic(fmt.Sprintf("memory-mapping log file %s (%d bytes): %v", f.name, f.size, err))
 		}
 		f.mapped = m
 	}
-	return f.mapped
+	return f.mapped, nil
 }
 
 // reader returns a file's handle for positioned reads, opening it on first
@@ -624,6 +644,10 @@ func (l *FilesystemLog) mapping(f *logFile, closed bool) []byte {
 func (l *FilesystemLog) reader(f *logFile) (*os.File, error) {
 	l.mapMu.Lock()
 	defer l.mapMu.Unlock()
+	return l.readerLocked(f)
+}
+
+func (l *FilesystemLog) readerLocked(f *logFile) (*os.File, error) {
 	if f.reader == nil {
 		file, err := os.Open(filepath.Join(l.dir, f.name))
 		if err != nil {
@@ -732,20 +756,22 @@ func (l *FilesystemLog) Read(ctx context.Context, fromRevision Revision, callbac
 // Close flushes queued transactions, rotates the active file so that
 // everything committed is archived, waits for uploads, and releases the log.
 func (l *FilesystemLog) Close() error {
+	var errs []error
 	if err := l.batching.Close(); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	close(l.stop)
 	<-l.rotatorDone
 
 	l.writeMu.Lock()
 	l.mu.Lock()
-	var err error
 	if l.opts.Archive != nil {
-		err = l.rotateLocked()
+		if err := l.rotateLocked(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if cerr := l.active.Close(); err == nil {
-		err = cerr
+	if err := l.active.Close(); err != nil {
+		errs = append(errs, err)
 	}
 	l.mu.Unlock()
 	l.writeMu.Unlock()
@@ -759,13 +785,13 @@ func (l *FilesystemLog) Close() error {
 
 	l.mapMu.Lock()
 	for _, f := range l.files {
-		if uerr := unmapFile(f.mapped); uerr != nil && err == nil {
-			err = uerr
+		if err := munmapFile(f.mapped); err != nil {
+			errs = append(errs, err)
 		}
 		f.mapped = nil
 		if f.reader != nil {
-			if cerr := f.reader.Close(); cerr != nil && err == nil {
-				err = cerr
+			if err := f.reader.Close(); err != nil {
+				errs = append(errs, err)
 			}
 			f.reader = nil
 		}
@@ -773,11 +799,11 @@ func (l *FilesystemLog) Close() error {
 	l.mapMu.Unlock()
 
 	if l.removeOnClose {
-		if rerr := os.RemoveAll(l.dir); err == nil {
-			err = rerr
+		if err := os.RemoveAll(l.dir); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 // SetListener sets the log listener

--- a/pkg/persistence/filesystemlog/mmap_other.go
+++ b/pkg/persistence/filesystemlog/mmap_other.go
@@ -16,10 +16,13 @@
 
 package filesystemlog
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
 var errNoMmap = errors.New("memory mapping is not supported on this platform")
 
-func mapFile(path string, size int64) ([]byte, error) { return nil, errNoMmap }
+func mmapFile(f *os.File, size int64) ([]byte, error) { return nil, errNoMmap }
 
-func unmapFile(m []byte) error { return nil }
+func munmapFile(m []byte) error { return nil }

--- a/pkg/persistence/filesystemlog/mmap_other.go
+++ b/pkg/persistence/filesystemlog/mmap_other.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !unix
+
+package filesystemlog
+
+import "errors"
+
+var errNoMmap = errors.New("memory mapping is not supported on this platform")
+
+func mapFile(path string, size int64) ([]byte, error) { return nil, errNoMmap }
+
+func unmapFile(m []byte) error { return nil }

--- a/pkg/persistence/filesystemlog/mmap_unix.go
+++ b/pkg/persistence/filesystemlog/mmap_unix.go
@@ -22,26 +22,21 @@ import (
 	"syscall"
 )
 
-// errNoMmap is returned by mapFile on platforms without memory mapping;
+// errNoMmap is returned by mmapFile on platforms without memory mapping;
 // never on this one.
 var errNoMmap = errors.New("memory mapping is not supported on this platform")
 
-// mapFile maps a whole file read-only. The mapping is backed by the page
-// cache: pages are read on first touch and evicted by the OS under memory
-// pressure, so old records cost no heap.
-func mapFile(path string, size int64) ([]byte, error) {
+// mmapFile maps the first size bytes of f read-only. The mapping is backed
+// by the page cache: pages are read on first touch and evicted by the OS
+// under memory pressure, so old records cost no heap.
+func mmapFile(f *os.File, size int64) ([]byte, error) {
 	if size == 0 {
 		return nil, nil
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
 	return syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
 }
 
-func unmapFile(m []byte) error {
+func munmapFile(m []byte) error {
 	if m == nil {
 		return nil
 	}

--- a/pkg/persistence/filesystemlog/mmap_unix.go
+++ b/pkg/persistence/filesystemlog/mmap_unix.go
@@ -17,9 +17,14 @@
 package filesystemlog
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
+
+// errNoMmap is returned by mapFile on platforms without memory mapping;
+// never on this one.
+var errNoMmap = errors.New("memory mapping is not supported on this platform")
 
 // mapFile maps a whole file read-only. The mapping is backed by the page
 // cache: pages are read on first touch and evicted by the OS under memory

--- a/pkg/persistence/filesystemlog/mmap_unix.go
+++ b/pkg/persistence/filesystemlog/mmap_unix.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Justin Santa Barbara
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package filesystemlog
+
+import (
+	"os"
+	"syscall"
+)
+
+// mapFile maps a whole file read-only. The mapping is backed by the page
+// cache: pages are read on first touch and evicted by the OS under memory
+// pressure, so old records cost no heap.
+func mapFile(path string, size int64) ([]byte, error) {
+	if size == 0 {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func unmapFile(m []byte) error {
+	if m == nil {
+		return nil
+	}
+	return syscall.Munmap(m)
+}

--- a/pkg/persistence/logcodec/logcodec.go
+++ b/pkg/persistence/logcodec/logcodec.go
@@ -30,6 +30,7 @@ import (
 	"io"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
@@ -176,4 +177,128 @@ func Decode(data []byte) ([]*persistence.LogRecord, error) {
 		records = append(records, &persistence.LogRecord{Events: wr.Events})
 	}
 	return records, nil
+}
+
+// DecodeMessageAlias is DecodeMessage without copying: the returned record's
+// keys and values alias m, so m must stay valid and unmodified for as long as
+// the record is in use (a read-only mapping of a closed log file is). It
+// parses exactly the fields of etcdserverpb.WatchResponse, mvccpb.Event and
+// mvccpb.KeyValue that the log writes, and skips any others.
+func DecodeMessageAlias(m []byte) (*persistence.LogRecord, error) {
+	record := &persistence.LogRecord{}
+	for len(m) > 0 {
+		num, typ, n := protowire.ConsumeTag(m)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		m = m[n:]
+		if num == 11 && typ == protowire.BytesType { // WatchResponse.events
+			v, n := protowire.ConsumeBytes(m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			ev, err := decodeEventAlias(v)
+			if err != nil {
+				return nil, err
+			}
+			record.Events = append(record.Events, ev)
+			m = m[n:]
+			continue
+		}
+		n = protowire.ConsumeFieldValue(num, typ, m)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		m = m[n:]
+	}
+	return record, nil
+}
+
+func decodeEventAlias(m []byte) (*mvccpb.Event, error) {
+	ev := &mvccpb.Event{}
+	for len(m) > 0 {
+		num, typ, n := protowire.ConsumeTag(m)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		m = m[n:]
+		switch {
+		case num == 1 && typ == protowire.VarintType: // type
+			v, n := protowire.ConsumeVarint(m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			ev.Type = mvccpb.Event_EventType(v)
+			m = m[n:]
+		case (num == 2 || num == 3) && typ == protowire.BytesType: // kv, prev_kv
+			v, n := protowire.ConsumeBytes(m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			kv, err := decodeKeyValueAlias(v)
+			if err != nil {
+				return nil, err
+			}
+			if num == 2 {
+				ev.Kv = kv
+			} else {
+				ev.PrevKv = kv
+			}
+			m = m[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			m = m[n:]
+		}
+	}
+	return ev, nil
+}
+
+func decodeKeyValueAlias(m []byte) (*mvccpb.KeyValue, error) {
+	kv := &mvccpb.KeyValue{}
+	for len(m) > 0 {
+		num, typ, n := protowire.ConsumeTag(m)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		m = m[n:]
+		switch {
+		case (num == 1 || num == 5) && typ == protowire.BytesType: // key, value
+			v, n := protowire.ConsumeBytes(m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			if num == 1 {
+				kv.Key = v
+			} else {
+				kv.Value = v
+			}
+			m = m[n:]
+		case typ == protowire.VarintType && num >= 2 && num <= 6: // create_revision, mod_revision, version, lease
+			v, n := protowire.ConsumeVarint(m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			switch num {
+			case 2:
+				kv.CreateRevision = int64(v)
+			case 3:
+				kv.ModRevision = int64(v)
+			case 4:
+				kv.Version = int64(v)
+			case 6:
+				kv.Lease = int64(v)
+			}
+			m = m[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, m)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			m = m[n:]
+		}
+	}
+	return kv, nil
 }

--- a/pkg/persistence/logcodec/logcodec_test.go
+++ b/pkg/persistence/logcodec/logcodec_test.go
@@ -17,6 +17,7 @@ package logcodec
 import (
 	"fmt"
 	"testing"
+	"unsafe"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"google.golang.org/protobuf/proto"
@@ -134,6 +135,68 @@ func TestOffsets(t *testing.T) {
 	}
 	if _, err := Offsets(data[:len(data)-5]); err == nil {
 		t.Error("offsets of a truncated batch succeeded")
+	}
+}
+
+func TestDecodeMessageAlias(t *testing.T) {
+	in := batch(50)
+	data, err := Encode(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans, err := Offsets(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, sp := range spans {
+		m := data[sp.Offset : sp.Offset+sp.Length]
+		got, err := DecodeMessageAlias(m)
+		if err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+		want, _ := DecodeMessage(m)
+		if len(got.Events) != len(want.Events) {
+			t.Fatalf("record %d: %d events, want %d", i, len(got.Events), len(want.Events))
+		}
+		for j := range want.Events {
+			if !proto.Equal(got.Events[j], want.Events[j]) {
+				t.Fatalf("record %d event %d:\n got %v\nwant %v", i, j, got.Events[j], want.Events[j])
+			}
+		}
+		// The alias decoder shares the input buffer rather than copying.
+		if len(got.Events) > 0 && got.Events[0].Kv != nil && len(got.Events[0].Kv.Value) > 0 {
+			v := got.Events[0].Kv.Value
+			start, end := uintptr(unsafe.Pointer(&m[0])), uintptr(unsafe.Pointer(&m[len(m)-1]))
+			if p := uintptr(unsafe.Pointer(&v[0])); p < start || p > end {
+				t.Fatalf("record %d: value was copied instead of aliased", i)
+			}
+		}
+	}
+}
+
+func BenchmarkDecodeMessageAlias(b *testing.B) {
+	data, _ := Encode(batch(500))
+	spans, _ := Offsets(data)
+	sp := spans[250]
+	m := data[sp.Offset : sp.Offset+sp.Length]
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeMessageAlias(m); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeMessage(b *testing.B) {
+	data, _ := Encode(batch(500))
+	spans, _ := Offsets(data)
+	sp := spans[250]
+	m := data[sp.Offset : sp.Offset+sp.Length]
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeMessage(m); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Supersedes #55 (GitHub would not retarget it after its base branch, #53's, was merged and deleted). The review on #55 is addressed here: each file keeps a read handle for positioned reads instead of reopening on every read, and a failed mmap is fatal rather than a silent fallback to `pread` (only the `!unix` build reads that way, by design).

Old objects, as discussed: a **closed** log file is memory-mapped read-only on first read and stays mapped until the log closes. Records read from a mapping are decoded by a small `protowire` parser (`logcodec.DecodeMessageAlias`) that **aliases key and value bytes into the mapping** instead of copying them — a record costs a few struct headers on the heap, and its bytes live in the page cache, which the OS evicts under memory pressure. Old-object residency is the kernel's job now, not the record cache's. The active file (still growing) keeps positioned reads; non-Unix platforms fall back to them.

The alias decoder is checked against `proto.Unmarshal` with `proto.Equal` on records with PUT+prev_kv and DELETE events, and the test asserts the value really is aliased. Decoding one 1 KB record with prev_kv: **460 ns / 574 B / 8 allocs** vs 1.6 µs / 1.9 KB / 14 allocs.

## Measurement (100k nodes, 512 workers, `cache=1MB` so reads are cold, `rotateBytes=16MB` so files are closed)

| | before | after |
|---|---|---|
| list-storm: 8 concurrent full lists of 100k nodes | 9.32 s | **7.15 s** |
| heap during steady | 135 MB | 120 MB |
| writes/s | 9,939 | 9,939 |

Moderate on this workload — 2 KB values make the copy a modest part of a read — but the point is where the bytes live.

## Test plan

- [x] `TestDecodeMessageAlias` (equality with proto, aliasing asserted), benchmarks
- [x] Log conformance suite, rotation, torn-tail and archive round-trip tests (closed files now read via mappings), `go test -race ./pkg/persistence/...`
- [x] `go test ./...` 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek

