### PR TITLE
Return etcd's compaction errors from Range and Watch

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -322,15 +322,16 @@ func (s *Server) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdse
 	return result, nil
 }
 
-// toGRPCError maps storage errors to their etcd equivalents, so that
-// clients see the errors they are coded to handle (kube-apiserver relists
-// on ErrGRPCCompacted); anything else passes through.
+// toGRPCError reduces an error wrapping one of the etcd rpc sentinels
+// (storage.ErrCompacted, storage.ErrFutureRev — the sentinels are the rpc
+// errors, wrapped with context on the way up) back to the bare sentinel,
+// which is the status error gRPC sends and clients are coded to handle;
+// kube-apiserver relists on ErrGRPCCompacted. Anything else passes through.
 func toGRPCError(err error) error {
-	switch {
-	case errors.Is(err, storage.ErrCompacted):
-		return rpctypes.ErrGRPCCompacted
-	case errors.Is(err, storage.ErrFutureRev):
-		return rpctypes.ErrGRPCFutureRev
+	for _, sentinel := range []error{rpctypes.ErrGRPCCompacted, rpctypes.ErrGRPCFutureRev} {
+		if errors.Is(err, sentinel) {
+			return sentinel
+		}
 	}
 	return err
 }
@@ -459,6 +460,7 @@ func (ws *watchStream) handleCreateRequest(ctx context.Context, req *etcdserverp
 			// stream itself stays up for its other watches.
 			current, cerr := ws.server.storage.GetCurrentRevision(ctx)
 			if cerr != nil {
+				log.Error(cerr, "failed to get current revision for compacted-watch cancel; using the compacted revision in the header")
 				current = logPosition
 			}
 			ws.stream.Send(&etcdserverpb.WatchResponse{

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -277,7 +278,7 @@ func (s *Server) handleSingleKey(ctx context.Context, req *etcdserverpb.RangeReq
 	// Query for single key
 	resp, err := s.storage.Get(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, toGRPCError(err)
 	}
 	return resp, err
 }
@@ -286,7 +287,7 @@ func (s *Server) handleRangeWithEnd(ctx context.Context, req *etcdserverpb.Range
 	// Use the storage layer's efficient range query
 	resp, err := s.storage.List(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, toGRPCError(err)
 	}
 	return resp, err
 }
@@ -316,9 +317,22 @@ func (s *Server) Txn(ctx context.Context, req *etcdserverpb.TxnRequest) (*etcdse
 	result, err := s.storage.Txn(ctx, req)
 	if err != nil {
 		log.Error(err, "failed to execute Txn request", "request", req)
-		return nil, err
+		return nil, toGRPCError(err)
 	}
 	return result, nil
+}
+
+// toGRPCError maps storage errors to their etcd equivalents, so that
+// clients see the errors they are coded to handle (kube-apiserver relists
+// on ErrGRPCCompacted); anything else passes through.
+func toGRPCError(err error) error {
+	switch {
+	case errors.Is(err, storage.ErrCompacted):
+		return rpctypes.ErrGRPCCompacted
+	case errors.Is(err, storage.ErrFutureRev):
+		return rpctypes.ErrGRPCFutureRev
+	}
+	return err
 }
 
 // Compact implements the Compact RPC method
@@ -438,6 +452,28 @@ func (ws *watchStream) handleCreateRequest(ctx context.Context, req *etcdserverp
 	// Create storage watcher
 	watch, logPosition, err := ws.server.storage.Watch(ctx, req, callback)
 	if err != nil {
+		if errors.Is(err, storage.ErrCompacted) {
+			// As in etcd: the watch is created and at once canceled, with
+			// CompactRevision (the compacted revision, which Watch returned
+			// in the revision slot) telling the client where to relist. The
+			// stream itself stays up for its other watches.
+			current, cerr := ws.server.storage.GetCurrentRevision(ctx)
+			if cerr != nil {
+				current = logPosition
+			}
+			ws.stream.Send(&etcdserverpb.WatchResponse{
+				Header:  ws.server.createHeader(current),
+				WatchId: watchID,
+				Created: true,
+			})
+			ws.stream.Send(&etcdserverpb.WatchResponse{
+				Header:          ws.server.createHeader(current),
+				WatchId:         watchID,
+				Canceled:        true,
+				CompactRevision: int64(logPosition),
+			})
+			return nil
+		}
 		// Send error response
 		resp := &etcdserverpb.WatchResponse{
 			Header: ws.server.createHeader(logPosition),

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -16,12 +16,14 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"justinsb.com/cloudetcd/pkg/persistence/memorylog"
 	"justinsb.com/cloudetcd/pkg/storage/memorystorage"
@@ -552,4 +554,63 @@ func TestRangeWithRangeEnd(t *testing.T) {
 	require.Contains(t, keys, "b")
 	require.NotContains(t, keys, "c")
 	require.NotContains(t, keys, "d")
+}
+
+// TestCompactedErrors checks what an etcd client sees around the compaction
+// point: ErrCompacted for a range below it, ErrFutureRev beyond head, and
+// for a watch starting at or below it a canceled watch carrying
+// CompactRevision (kube-apiserver relists on exactly these).
+func TestCompactedErrors(t *testing.T) {
+	ctx := t.Context()
+
+	store, err := memorystorage.NewMemoryStorage(memorylog.New())
+	require.NoError(t, err)
+	server := NewServer(store)
+	defer server.GracefulStop()
+	go func() {
+		if err := server.Start(ctx, ":21390"); err != nil {
+			t.Errorf("Failed to start server: %v", err)
+		}
+	}()
+	time.Sleep(500 * time.Millisecond)
+
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{"localhost:21390"}, DialTimeout: 5 * time.Second})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var putRev []int64
+	for i := 0; i < 10; i++ {
+		resp, err := cli.Put(ctx, "compact-key", fmt.Sprintf("v%d", i))
+		require.NoError(t, err)
+		putRev = append(putRev, resp.Header.Revision)
+	}
+	point := putRev[5]
+	_, err = cli.Compact(ctx, point)
+	require.NoError(t, err)
+
+	// Reads at the point work; below it and beyond head fail as in etcd.
+	resp, err := cli.Get(ctx, "compact-key", clientv3.WithRev(point))
+	require.NoError(t, err)
+	require.Equal(t, "v5", string(resp.Kvs[0].Value))
+	_, err = cli.Get(ctx, "compact-key", clientv3.WithRev(point-1))
+	require.ErrorIs(t, err, rpctypes.ErrCompacted)
+	_, err = cli.Get(ctx, "compact-key", clientv3.WithPrefix(), clientv3.WithRev(point-1))
+	require.ErrorIs(t, err, rpctypes.ErrCompacted)
+	_, err = cli.Get(ctx, "compact-key", clientv3.WithRev(99))
+	require.ErrorIs(t, err, rpctypes.ErrFutureRev)
+
+	// A watch from at or below the point is canceled with CompactRevision.
+	wresp := <-cli.Watch(ctx, "compact-key", clientv3.WithRev(point-1))
+	require.True(t, wresp.Canceled)
+	require.Equal(t, int64(point), wresp.CompactRevision)
+	require.ErrorIs(t, wresp.Err(), rpctypes.ErrCompacted)
+
+	// A watch from above the point replays from there.
+	wresp = <-cli.Watch(ctx, "compact-key", clientv3.WithRev(point+1))
+	require.NoError(t, wresp.Err())
+	require.NotEmpty(t, wresp.Events)
+	require.Equal(t, int64(point+1), wresp.Events[0].Kv.ModRevision)
 }

--- a/pkg/persistence/log.go
+++ b/pkg/persistence/log.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 type Revision uint64
@@ -31,8 +32,11 @@ type Revision uint64
 var ErrRevisionConflict = errors.New("log revision already claimed by another writer")
 
 // ErrCompacted is returned when a revision below the compaction point is
-// requested: its history has been discarded.
-var ErrCompacted = errors.New("revision has been compacted")
+// requested: its history has been discarded. It is etcd's ErrGRPCCompacted,
+// so the error keeps one identity from the log to the wire: layers add
+// context by wrapping it, and the API strips the wrapping off again before
+// sending (gRPC wants the bare status error).
+var ErrCompacted error = rpctypes.ErrGRPCCompacted
 
 // LogRecord represents a single entry in the log
 type LogRecord struct {

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -15,6 +15,7 @@
 package memorystorage
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -25,6 +26,7 @@ import (
 
 	"justinsb.com/cloudetcd/pkg/persistence/filesystemlog"
 	"justinsb.com/cloudetcd/pkg/persistence/memorylog"
+	"justinsb.com/cloudetcd/pkg/storage"
 )
 
 // TestConcurrentConditionalUpdatesSerialize races N compare-and-put
@@ -360,4 +362,57 @@ func TestCompactKeepsStateAtPoint(t *testing.T) {
 	if got := snapshot(store, head); got != atHead {
 		t.Fatalf("state at head after restart:\n before %s\n after  %s", atHead, got)
 	}
+}
+
+// TestCompactedReadsAndWatches checks the compaction-point semantics at the
+// storage API: reads at or above the point (and no further than head) work,
+// reads below it are ErrCompacted, reads beyond head are ErrFutureRev, and a
+// watch may only start above the point (a refused watch reports the point).
+func TestCompactedReadsAndWatches(t *testing.T) {
+	ctx := t.Context()
+	lg, err := filesystemlog.NewFilesystemLogWithOptions(t.TempDir(), filesystemlog.Options{CacheBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewMemoryStorage(lg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.log.Close()
+
+	var putRev []Revision
+	for i := 0; i < 10; i++ {
+		resp, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: []byte("/k"), Value: []byte(fmt.Sprintf("v%d", i))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		putRev = append(putRev, Revision(resp.Header.Revision))
+	}
+	point := putRev[5]
+	if compacted, err := store.Compact(ctx, point); err != nil || compacted != point {
+		t.Fatalf("Compact = %d, %v; want %d", compacted, err, point)
+	}
+
+	if resp, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k"), Revision: int64(point)}); err != nil || string(resp.Kvs[0].Value) != "v5" {
+		t.Fatalf("read at the compaction point: %v, %v", resp.GetKvs(), err)
+	}
+	if _, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k"), Revision: int64(point - 1)}); !errors.Is(err, storage.ErrCompacted) {
+		t.Fatalf("read below the compaction point: got %v, want ErrCompacted", err)
+	}
+	if _, err := store.List(ctx, &etcdserverpb.RangeRequest{Key: []byte("/"), RangeEnd: []byte("0"), Revision: int64(point - 1)}); !errors.Is(err, storage.ErrCompacted) {
+		t.Fatalf("list below the compaction point: got %v, want ErrCompacted", err)
+	}
+	if _, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k"), Revision: 99}); !errors.Is(err, storage.ErrFutureRev) {
+		t.Fatalf("read beyond head: got %v, want ErrFutureRev", err)
+	}
+
+	cb := func(*etcdserverpb.WatchResponse) error { return nil }
+	if _, rev, err := store.Watch(ctx, &etcdserverpb.WatchCreateRequest{WatchId: 1, Key: []byte("/k"), StartRevision: int64(point)}, cb); !errors.Is(err, storage.ErrCompacted) || rev != point {
+		t.Fatalf("watch from the compaction point: got rev %d, %v; want ErrCompacted with rev %d", rev, err, point)
+	}
+	w, _, err := store.Watch(ctx, &etcdserverpb.WatchCreateRequest{WatchId: 2, Key: []byte("/k"), StartRevision: int64(point + 1)}, cb)
+	if err != nil {
+		t.Fatalf("watch from above the compaction point: %v", err)
+	}
+	w.Close()
 }

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -613,6 +613,9 @@ func (t *txn) get(ctx context.Context, req *etcdserverpb.RangeRequest) (*etcdser
 	snapshotTimestamp := t.snapshotTimestamp
 	if req.Revision > 0 {
 		snapshotTimestamp = Revision(req.Revision)
+		if err := m.checkReadRevision(snapshotTimestamp, t.snapshotTimestamp); err != nil {
+			return nil, err
+		}
 	}
 
 	if req.CountOnly {
@@ -666,6 +669,21 @@ func (t *txn) get(ctx context.Context, req *etcdserverpb.RangeRequest) (*etcdser
 	default:
 		panic(fmt.Sprintf("unknown operation: %s", event.Type))
 	}
+}
+
+// checkReadRevision rejects a requested read revision outside the readable
+// window: at or below the compacted revision the history is gone (reads at
+// the compacted revision itself still work: compaction keeps each key's
+// state as of that point), and beyond the current revision there is nothing
+// yet. Called with mu held (evaluate holds it for get and list).
+func (m *MemoryStorage) checkReadRevision(requested, current Revision) error {
+	if requested < m.compacted {
+		return fmt.Errorf("requested revision %d is below the compacted revision %d: %w", requested, m.compacted, storage.ErrCompacted)
+	}
+	if requested > current {
+		return fmt.Errorf("requested revision %d is beyond the current revision %d: %w", requested, current, storage.ErrFutureRev)
+	}
+	return nil
 }
 
 func findEvent(logEntry *persistence.LogRecord, key []byte) *mvccpb.Event {
@@ -862,6 +880,9 @@ func (t *txn) list(ctx context.Context, req *etcdserverpb.RangeRequest) (*etcdse
 	snapshotTimestamp := t.snapshotTimestamp
 	if req.Revision > 0 {
 		snapshotTimestamp = Revision(req.Revision)
+		if err := m.checkReadRevision(snapshotTimestamp, t.snapshotTimestamp); err != nil {
+			return nil, err
+		}
 	}
 
 	resp := &etcdserverpb.RangeResponse{

--- a/pkg/storage/memorystorage/watch.go
+++ b/pkg/storage/memorystorage/watch.go
@@ -41,6 +41,19 @@ type Revision = storage.Revision
 // If rangeEnd is empty, it watches a single key.
 // If rangeEnd is specified, it watches the range [key, rangeEnd).
 func (m *MemoryStorage) Watch(ctx context.Context, req *etcdserverpb.WatchCreateRequest, callback func(event *etcdserverpb.WatchResponse) error) (storage.Watcher, Revision, error) {
+	// A watch replays every record from its start revision on, and records
+	// at or below the compacted revision are not all there (even at the
+	// point itself a delete may be gone, which is why this is <= where the
+	// read path's check is <). The compacted revision is returned for the
+	// client's CompactRevision: it relists at or above it and watches from
+	// above it. Read before watcherMu: mu comes first in the lock order.
+	m.mu.RLock()
+	compacted := m.compacted
+	m.mu.RUnlock()
+	if start := Revision(req.StartRevision); start > 0 && start <= compacted {
+		return nil, compacted, fmt.Errorf("watch start revision %d is at or below the compacted revision %d: %w", start, compacted, storage.ErrCompacted)
+	}
+
 	m.watcherMu.Lock()
 	defer m.watcherMu.Unlock()
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,10 +16,10 @@ package storage
 
 import (
 	"context"
-	"errors"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"justinsb.com/cloudetcd/pkg/persistence"
 )
 
@@ -29,15 +29,14 @@ type Revision = persistence.Revision
 // TODO: Just use zero to mean latest revision?
 const MAX_REVISION = Revision(^uint64(0))
 
-// ErrCompacted is returned for reads of history at or below the compacted
-// revision (it is persistence.ErrCompacted, re-exported for the layers
-// above storage). The API maps it to etcd's ErrGRPCCompacted, which is what
-// kube-apiserver relists on.
+// ErrCompacted is returned for reads of history below the compacted
+// revision (persistence.ErrCompacted re-exported, which is etcd's
+// ErrGRPCCompacted — what kube-apiserver relists on).
 var ErrCompacted = persistence.ErrCompacted
 
-// ErrFutureRev is returned for reads at a revision beyond the current one.
-// The API maps it to etcd's ErrGRPCFutureRev.
-var ErrFutureRev = errors.New("revision is in the future")
+// ErrFutureRev is returned for reads at a revision beyond the current one:
+// etcd's ErrGRPCFutureRev, wrapped with context like ErrCompacted.
+var ErrFutureRev error = rpctypes.ErrGRPCFutureRev
 
 // // KeyValue represents a single key-value pair from the store with MVCC support.
 // type KeyValue struct {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -27,6 +28,16 @@ type Revision = persistence.Revision
 
 // TODO: Just use zero to mean latest revision?
 const MAX_REVISION = Revision(^uint64(0))
+
+// ErrCompacted is returned for reads of history at or below the compacted
+// revision (it is persistence.ErrCompacted, re-exported for the layers
+// above storage). The API maps it to etcd's ErrGRPCCompacted, which is what
+// kube-apiserver relists on.
+var ErrCompacted = persistence.ErrCompacted
+
+// ErrFutureRev is returned for reads at a revision beyond the current one.
+// The API maps it to etcd's ErrGRPCFutureRev.
+var ErrFutureRev = errors.New("revision is in the future")
 
 // // KeyValue represents a single key-value pair from the store with MVCC support.
 // type KeyValue struct {
@@ -75,6 +86,9 @@ type Storage interface {
 	// Watch creates a watcher for the given key/range starting from the specified revision
 	// If rangeEnd is empty, it watches a single key.
 	// If rangeEnd is specified, it watches the range [key, rangeEnd).
+	// A start revision at or below the compacted revision is refused with an
+	// error wrapping ErrCompacted; the returned Revision is then the
+	// compacted revision, for the client's WatchResponse.CompactRevision.
 	Watch(ctx context.Context, req *etcdserverpb.WatchCreateRequest, callback func(event *etcdserverpb.WatchResponse) error) (Watcher, Revision, error)
 
 	// Txn executes a transaction against the storage.


### PR DESCRIPTION
With #56 merged, reads below the compaction point failed as internal errors (or quietly returned what the pruned index suggested). This PR gives them etcd's semantics, which kube-apiserver depends on to relist:

- **Range/Txn** at a revision below the compacted point → `ErrGRPCCompacted`; beyond head → `ErrGRPCFutureRev`. Reads **at** the point keep working — compaction keeps each key's state there (per #56's `TestCompactKeepsStateAtPoint`).
- **Watch** starting at or below the point → created and at once canceled with `CompactRevision` set, as etcd does, leaving the stream up for its other watches. Watches must start *above* the point (etcd allows `==`): a delete record at exactly the point may have been dropped, since a deleted key leaves the index. The comment in `Watch` spells this out.
- Storage-side: one `checkReadRevision(requested, current)` in `get`/`list` under the lock `evaluate` already holds; `Watch` returns the compacted revision through its existing revision slot for the API to hand to the client. API-side: `toGRPCError` maps `storage.ErrCompacted`/`storage.ErrFutureRev` (new; the former re-exports `persistence.ErrCompacted`).

Tests: `TestCompactedReadsAndWatches` at the storage API, and `TestCompactedErrors` through a real clientv3 — asserting `rpctypes.ErrCompacted`/`ErrFutureRev` and the canceled watch's `CompactRevision`, plus that a watch from just above the point replays history. Race-clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek