### PR TITLE
Fix the watch-test goroutine flake

### DIFF
--- a/pkg/storage/memorystorage/storage_test.go
+++ b/pkg/storage/memorystorage/storage_test.go
@@ -15,6 +15,8 @@
 package memorystorage
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -481,10 +483,17 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		defer watcher.Close()
-
+		// Join the watcher's goroutine before the subtest returns: the test
+		// context outlives the subtest, and a t.Errorf from a goroutine
+		// after the subtest has completed panics. A canceled context is a
+		// normal way for the run to end at teardown, not a failure.
+		runDone := make(chan error, 1)
 		go func() {
-			if err := watcher.Run(ctx); err != nil {
+			runDone <- watcher.Run(ctx)
+		}()
+		defer func() {
+			watcher.Close()
+			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()
@@ -579,10 +588,17 @@ func TestMemoryStorage_Watch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create watcher: %v", err)
 		}
-		defer watcher.Close()
-
+		// Join the watcher's goroutine before the subtest returns: the test
+		// context outlives the subtest, and a t.Errorf from a goroutine
+		// after the subtest has completed panics. A canceled context is a
+		// normal way for the run to end at teardown, not a failure.
+		runDone := make(chan error, 1)
 		go func() {
-			if err := watcher.Run(ctx); err != nil {
+			runDone <- watcher.Run(ctx)
+		}()
+		defer func() {
+			watcher.Close()
+			if err := <-runDone; err != nil && !errors.Is(err, context.Canceled) {
 				t.Errorf("watch stopped with error: %v", err)
 			}
 		}()


### PR DESCRIPTION
CI flake seen on #60: the two watch subtests spawned `watcher.Run(ctx)` on the test-wide context and never joined the goroutine. When the parent test finished, `t.Context()` was canceled, `Run` returned `context.Canceled`, and the goroutine's `t.Errorf` hit a completed subtest — `panic: Log in goroutine after TestMemoryStorage_Watch/Storage_Prefix_Watch has completed`.

Each subtest now closes its watcher and waits for `Run` to return before finishing (so nothing can log after completion), and a canceled context at teardown is treated as a normal shutdown rather than a failure. A real `Run` error still fails the test, now deterministically inside the subtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek