### PR TITLE
Prune the index asynchronously, in chunks

### DIFF
--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -98,7 +98,7 @@ write throughput, watch event throughput and watch lag — not watcher count.
 
 ### Compaction
 
-The model issues `Compact` every 5 minutes as the apiserver does (`-compact-interval` shortens that). The server prunes its index to each key's latest version at or below the compaction point, drops deleted keys, and rewrites closed log files in the background keeping only live records (a compacted file is sparse in revision and named by the range it covers). The report's `log … MB on disk` per phase is how to see it: with compaction the log settles at the live set plus one interval's tail; without it the log grows at the write rate.
+The model issues `Compact` every 5 minutes as the apiserver does (`-compact-interval` shortens that). The server answers at once and does the rest in the background: it prunes its index to each key's latest version at or below the compaction point (a chunk of keys at a time, so the index is never locked long), drops deleted keys, and rewrites closed log files keeping only live records (a compacted file is sparse in revision and named by the range it covers). The report's `log … MB on disk` per phase is how to see it: with compaction the log settles at the live set plus one interval's tail; without it the log grows at the write rate.
 
 ## The gated stress test
 

--- a/pkg/bptree/bptree.go
+++ b/pkg/bptree/bptree.go
@@ -163,19 +163,64 @@ func (t *BPTree) AddRevision(key []byte, revision Revision, tombstone bool) {
 // through and the latest one below, which is all a read at or after through
 // can observe. A key whose latest revision is a delete at or below through is
 // removed. It returns the number of keys removed and revisions dropped.
+// It locks the tree for the whole walk; the server uses CompactFrom.
 func (t *BPTree) Compact(through Revision) (keysRemoved, revisionsDropped int) {
+	_, keysRemoved, revisionsDropped = t.CompactFrom(nil, through, 0)
+	return keysRemoved, revisionsDropped
+}
+
+// CompactFrom is Compact a chunk at a time: it prunes up to maxKeys keys in
+// key order (all of them if maxKeys <= 0), starting after start (from the
+// beginning if start is nil), and returns where to continue — nil when the
+// walk is done — with the counts. Callers loop over it, so the tree is
+// locked only a chunk at a time while reads and writes interleave. That is
+// sound because pruning only ever shrinks a key's revisions: revisions at
+// or above through, and everything written between chunks, are kept, and
+// reads pick each key's latest revision at or below their snapshot, which
+// pruning never touches for the snapshots still readable after Compact.
+func (t *BPTree) CompactFrom(start []byte, through Revision, maxKeys int) (next []byte, keysRemoved, revisionsDropped int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	dropped, gone := t.emptyKey.compact(through)
-	revisionsDropped += dropped
-	if gone {
-		keysRemoved++
+
+	s := &compactState{through: through, remaining: maxKeys}
+	if maxKeys <= 0 {
+		s.remaining = int(^uint(0) >> 1)
 	}
-	k, d := t.root.compact(through)
-	keysRemoved += k
-	revisionsDropped += d
-	t.keys -= keysRemoved
-	return keysRemoved, revisionsDropped
+	var walkStart []byte
+	if start == nil {
+		if t.emptyKey.revisions != nil {
+			dropped, gone := t.emptyKey.compact(through)
+			s.dropped += dropped
+			if gone {
+				s.removed++
+			}
+			s.remaining--
+		}
+		if s.remaining == 0 {
+			// Resume strictly after the empty key: at the first real key.
+			s.next = []byte{}
+		}
+	} else {
+		// Resume strictly after start: with byte-string keys, that is at or
+		// after start plus a zero byte.
+		walkStart = append(bytes.Clone(start), 0)
+	}
+	if s.next == nil {
+		t.root.compactWalk(make([]byte, 0, 256), walkStart, s)
+	}
+	t.keys -= s.removed
+	return s.next, s.removed, s.dropped
+}
+
+// compactState carries one CompactFrom chunk through the walk.
+type compactState struct {
+	through   Revision
+	remaining int
+	removed   int
+	dropped   int
+	// next is the last key pruned when the chunk ran out, nil while the
+	// walk should continue.
+	next []byte
 }
 
 // compactRevisions trims one key's revisions for Compact.
@@ -195,21 +240,55 @@ func compactRevisions(revisions []Revision, tombstone bool, through Revision) (k
 	return append(revisions[:0], revisions[i:]...), i, false
 }
 
-func (n *node) compact(through Revision) (keysRemoved, revisionsDropped int) {
-	for i := range n.entries {
+// compactWalk prunes the keys below this node in key order, skipping those
+// below start (relative to this node; nil once passed), stopping when the
+// chunk is used up. It returns false to unwind the walk, with state.next
+// set. The start handling mirrors (*node).list.
+func (n *node) compactWalk(path []byte, start []byte, s *compactState) bool {
+	i := 0
+	if len(start) > 0 {
+		i, _ = n.find(start[0])
+	}
+	for ; i < len(n.entries); i++ {
 		e := &n.entries[i]
-		dropped, gone := e.compact(through)
-		revisionsDropped += dropped
-		if gone {
-			keysRemoved++
+		childStart := []byte(nil)
+		pruneOwn := true
+		if len(start) > 0 {
+			m := min(len(e.prefix), len(start))
+			switch c := bytes.Compare(e.prefix[:m], start[:m]); {
+			case c < 0:
+				// The whole subtree is below start.
+				continue
+			case c == 0 && len(e.prefix) < len(start):
+				// start continues below this entry: the entry's own key is
+				// below start, and only part of its subtree qualifies.
+				pruneOwn = false
+				childStart = start[len(e.prefix):]
+			default:
+				// e.prefix >= start: everything from here on qualifies.
+			}
+			// Later siblings are entirely above start.
+			start = nil
+		}
+		key := append(path, e.prefix...)
+		if pruneOwn && e.revisions != nil {
+			dropped, gone := e.compact(s.through)
+			s.dropped += dropped
+			if gone {
+				s.removed++
+			}
+			if s.remaining--; s.remaining == 0 {
+				s.next = bytes.Clone(key)
+				return false
+			}
 		}
 		if e.child != nil {
-			k, d := e.child.compact(through)
-			keysRemoved += k
-			revisionsDropped += d
+			if !e.child.compactWalk(key, childStart, s) {
+				return false
+			}
 		}
 	}
-	return keysRemoved, revisionsDropped
+	return true
 }
 
 // addRevision adds revision for the key that continues with key from this

--- a/pkg/bptree/radix_test.go
+++ b/pkg/bptree/radix_test.go
@@ -276,3 +276,78 @@ func TestCompact(t *testing.T) {
 		t.Errorf("after compaction: %v", keys)
 	}
 }
+
+// TestCompactFrom checks that chunked compaction ends where one-pass
+// compaction does, even with the smallest chunks and with writes landing
+// between chunks.
+func TestCompactFrom(t *testing.T) {
+	build := func() *BPTree {
+		var tree BPTree
+		tree.AddRevision(nil, 1, false)
+		tree.AddRevision(nil, 9, false)
+		for k := 0; k < 50; k++ {
+			key := []byte(fmt.Sprintf("/reg/thing/%02d", k))
+			for r := 0; r < 4; r++ {
+				tree.AddRevision(key, Revision(1+k+50*r), false)
+			}
+			if k%5 == 0 {
+				tree.AddRevision(key, Revision(300+k), true)
+			}
+		}
+		return &tree
+	}
+	dump := func(tree *BPTree) string {
+		var out []string
+		tree.ListRevisionsByKeyRange(nil, 1000, func(key []byte, revisions []Revision) bool {
+			out = append(out, fmt.Sprintf("%s%v", key, revisions))
+			return true
+		})
+		return fmt.Sprintf("len=%d %v", tree.Len(), out)
+	}
+	const through = Revision(150)
+
+	want := build()
+	wantRemoved, wantDropped := want.Compact(through)
+
+	got := build()
+	var removed, dropped int
+	var chunks int
+	cursor, first := []byte(nil), true
+	for first || cursor != nil {
+		var k, d int
+		cursor, k, d = got.CompactFrom(cursor, through, 1)
+		removed += k
+		dropped += d
+		chunks++
+		first = false
+	}
+	if removed != wantRemoved || dropped != wantDropped {
+		t.Fatalf("chunked compaction removed %d/dropped %d, one-pass %d/%d", removed, dropped, wantRemoved, wantDropped)
+	}
+	if dump(got) != dump(want) {
+		t.Fatalf("chunked compaction differs:\n chunked %s\n one-pass %s", dump(got), dump(want))
+	}
+	if chunks < 40 {
+		t.Fatalf("chunk size 1 finished in %d chunks; the walk is not chunking", chunks)
+	}
+
+	// Writes between chunks: new revisions (above through) survive, both on
+	// existing keys and on keys the walk has already passed.
+	live := build()
+	cursor, first = nil, true
+	for first || cursor != nil {
+		cursor, _, _ = live.CompactFrom(cursor, through, 7)
+		live.AddRevision([]byte("/reg/thing/00"), Revision(400+len(cursor)), false)
+		live.AddRevision([]byte(fmt.Sprintf("/new/%02d", len(cursor))), 401, false)
+		first = false
+	}
+	if rev, ok := live.GetLatestRevisionByKey([]byte("/reg/thing/13"), 1000); !ok || rev != Revision(1+13+150) {
+		t.Fatalf("existing key after interleaved compaction: %d, %v", rev, ok)
+	}
+	if _, ok := live.GetLatestRevisionByKey([]byte("/new/00"), 1000); !ok {
+		t.Fatalf("key written between chunks is missing")
+	}
+	if rev, ok := live.GetLatestRevisionByKey([]byte("/reg/thing/00"), 399); !ok || rev != Revision(300) {
+		t.Fatalf("tombstone above through: %d, %v (want kept at 300)", rev, ok)
+	}
+}

--- a/pkg/persistence/filesystemlog/filesystem_log.go
+++ b/pkg/persistence/filesystemlog/filesystem_log.go
@@ -654,6 +654,24 @@ func (l *FilesystemLog) archive(op archiveOp) {
 	}
 }
 
+// CompactedFloor returns a lower bound on the log's compaction point, read
+// from its files: a sparse file holds only the records that were live at a
+// compaction, so history at or below the last revision such a file covers
+// has been discarded. (A dense file that compaction skipped for being
+// nearly all live can sit below the floor; reads into it still work, and
+// erring low only permits reads.)
+func (l *FilesystemLog) CompactedFloor() Revision {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var floor Revision
+	for _, f := range l.files {
+		if f.sparse && f.last > floor {
+			floor = f.last
+		}
+	}
+	return floor
+}
+
 // GetCurrentRevision returns the current revision number
 func (l *FilesystemLog) GetCurrentRevision(ctx context.Context) (Revision, error) {
 	l.mu.RLock()

--- a/pkg/persistence/log.go
+++ b/pkg/persistence/log.go
@@ -74,6 +74,11 @@ type Log interface {
 	// SetListener sets the log listener
 	SetListener(listener LogListener)
 
+	// CompactedFloor returns a lower bound on the revision the log has been
+	// compacted through — reads at or below it may fail with ErrCompacted —
+	// recovered from the log itself, so it survives a restart.
+	CompactedFloor() Revision
+
 	// Compact discards records at or below through that are no longer live:
 	// deletes, and puts that live(key, revision) reports have been
 	// superseded. Records above through, and the latest put of every key,

--- a/pkg/storage/memorystorage/concurrent_test.go
+++ b/pkg/storage/memorystorage/concurrent_test.go
@@ -416,3 +416,42 @@ func TestCompactedReadsAndWatches(t *testing.T) {
 	}
 	w.Close()
 }
+
+// TestCompactedGateSurvivesRestart checks that the reads-below-the-point
+// gate is rebuilt from the log on startup: the compaction point is not
+// stored anywhere else, and before the log reported its floor a restarted
+// server answered reads below the point from the pruned index (absent keys)
+// instead of refusing them.
+func TestCompactedGateSurvivesRestart(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	opts := filesystemlog.Options{RotateBytes: 2000}
+	store := openStore(t, dir, opts)
+	defer func() { store.log.Close() }()
+
+	var putRev []Revision
+	for i := 0; i < 200; i++ {
+		resp, err := store.Put(ctx, &etcdserverpb.PutRequest{Key: []byte(fmt.Sprintf("/k/%02d", i%10)), Value: []byte(fmt.Sprintf("v%d", i))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		putRev = append(putRev, Revision(resp.Header.Revision))
+	}
+	point := putRev[150]
+	if compacted, err := store.Compact(ctx, point); err != nil || compacted != point {
+		t.Fatalf("Compact = %d, %v; want %d", compacted, err, point)
+	}
+	store.WaitForCompaction()
+
+	store = restart(t, store, dir, opts)
+	if _, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/01"), Revision: int64(putRev[50])}); !errors.Is(err, storage.ErrCompacted) {
+		t.Fatalf("read below the point after restart: got %v, want ErrCompacted", err)
+	}
+	cb := func(*etcdserverpb.WatchResponse) error { return nil }
+	if _, _, err := store.Watch(ctx, &etcdserverpb.WatchCreateRequest{WatchId: 1, Key: []byte("/k/01"), StartRevision: int64(putRev[50])}, cb); !errors.Is(err, storage.ErrCompacted) {
+		t.Fatalf("watch below the point after restart: got %v, want ErrCompacted", err)
+	}
+	if resp, err := store.Get(ctx, &etcdserverpb.RangeRequest{Key: []byte("/k/01"), Revision: int64(point)}); err != nil || len(resp.Kvs) == 0 {
+		t.Fatalf("read at the point after restart: %v, %v", resp.GetKvs(), err)
+	}
+}

--- a/pkg/storage/memorystorage/memory.go
+++ b/pkg/storage/memorystorage/memory.go
@@ -40,9 +40,12 @@ type MemoryStorage struct {
 
 	revisions bptree.BPTree
 
-	// compacted is the revision history has been discarded through.
+	// compacted is the revision history has been discarded through. Set on
+	// open from the log's own floor, so the gate survives a restart.
 	compacted Revision
-	compactWG sync.WaitGroup
+	// compactBgMu serializes the background halves of compactions.
+	compactBgMu sync.Mutex
+	compactWG   sync.WaitGroup
 
 	// applied is the highest log revision whose events have been applied to
 	// revisions (and the lease manager). Records are committed by the log's
@@ -73,6 +76,8 @@ func NewMemoryStorage(log persistence.Log) (*MemoryStorage, error) {
 	if err := ms.ReplayLog(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to replay log on startup: %w", err)
 	}
+	// The compaction gate survives a restart: the log knows its own floor.
+	ms.compacted = log.CompactedFloor()
 
 	return ms, nil
 }
@@ -1031,14 +1036,17 @@ func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revisio
 		m.mu.Unlock()
 		return m.compacted, nil
 	}
-	keysRemoved, revisionsDropped := m.revisions.Compact(through)
 	m.compacted = through
 	m.mu.Unlock()
-	klog.V(1).Infof("compacted index through revision %d: %d keys removed, %d revisions dropped", through, keysRemoved, revisionsDropped)
 
-	// The log rewrite runs in the background: it reads closed files and
-	// takes seconds at scale, and nothing waits on it. The log serializes
-	// compactions, so overlapping requests queue.
+	// Everything else runs in the background; overlapping requests queue on
+	// compactBgMu. The index is not pruned synchronously: reads pick each
+	// key's latest revision at or below their snapshot, and the snapshots
+	// still readable (checkReadRevision now gates on the new point) get the
+	// same answer from a pruned and an unpruned index, so the walk only
+	// reclaims memory — done a chunk of keys at a time, so the index is
+	// never locked for the whole tree. The log rewrite follows the prune,
+	// whose result its liveness test reads.
 	// A record is live if it is a key's state as of the compaction point:
 	// its latest put or delete at or below through, which is what the index
 	// kept. Not simply the key's latest revision: a read at a revision
@@ -1052,7 +1060,22 @@ func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revisio
 	m.compactWG.Add(1)
 	go func() {
 		defer m.compactWG.Done()
+		m.compactBgMu.Lock()
+		defer m.compactBgMu.Unlock()
+
 		start := time.Now()
+		var keysRemoved, revisionsDropped int
+		cursor, first := []byte(nil), true
+		for first || cursor != nil {
+			var k, d int
+			cursor, k, d = m.revisions.CompactFrom(cursor, through, compactIndexChunk)
+			keysRemoved += k
+			revisionsDropped += d
+			first = false
+		}
+		klog.V(1).Infof("pruned index through revision %d in %s: %d keys removed, %d revisions dropped", through, time.Since(start).Round(time.Millisecond), keysRemoved, revisionsDropped)
+
+		start = time.Now()
 		if err := m.log.Compact(context.Background(), through, live); err != nil {
 			klog.Errorf("compacting log through revision %d: %v", through, err)
 			return
@@ -1061,6 +1084,10 @@ func (m *MemoryStorage) Compact(ctx context.Context, revision Revision) (Revisio
 	}()
 	return through, nil
 }
+
+// compactIndexChunk is how many keys one CompactFrom call prunes, bounding
+// how long a background compaction holds the index's lock at a stretch.
+const compactIndexChunk = 4096
 
 // WaitForCompaction blocks until background log compactions have finished,
 // for tests.


### PR DESCRIPTION
The second index item from the backlog: `Compact` walked the whole bptree under the storage write lock before answering — most of the 36ms Compact RPC at 100k scale, with every read and write blocked behind it.

**Why no read-time filtering was needed:** reads already pick each key's latest revision at or below their snapshot, and `checkReadRevision` (from #59) gates on the new point synchronously — so for every snapshot still readable, a pruned and an unpruned index give byte-identical answers. The prune only reclaims memory. That means the RPC can record the point and return; the walk moves to the background compaction goroutine, ordered ahead of the log rewrite so the rewrite's liveness test reads the pruned index (keeping the delete-record semantics from #56 intact).

**Chunked, not just backgrounded:** a background walk that holds the tree lock for the full 30ms+ would still stall every read. `bptree.CompactFrom(start, through, maxKeys)` prunes up to 4096 keys per lock acquisition and returns a resume key. Interleaved writes are sound because pruning only shrinks a key's revisions — everything at or above `through`, and anything written between chunks, is kept; entries are never removed structurally, so the cursor stays valid. `Compact` remains as the one-pass wrapper. `TestCompactFrom` runs chunk-size-1 against one-pass and compares the full dump, then interleaves writes between chunks.

**Restart gap, fixed while here:** `m.compacted` lived only in memory, so after a restart the #59 gate was gone — reads below the point were answered from the pruned index (keys silently absent) instead of `ErrCompacted`. The log already knows its floor: the last revision any sparse (compacted) file covers. `Log.CompactedFloor()` recovers it on open; erring low only permits reads that still work. `TestCompactedGateSurvivesRestart` covers Get and Watch below and at the point after a restart.

Race-clean on bptree/memorystorage/filesystemlog; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSKELxD1vCXBTgMyL4c3Ek